### PR TITLE
Conda env + Installation procedure update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This `cloudformation` tool creates an EMR cluster under an **emr-5.24.0** releas
 This tool requires the following programs to be installed <!-- (if any of them is missing, they will be installed for you !) --> : 
 
 * Amazon's `Command Line Interface (CLI)` utility
-* `Conda` environment manager ( We suggest [Miniconda3](https://docs.conda.io/en/latest/miniconda.html))
+* `Conda` environment manager (We suggest [Miniconda3](https://docs.conda.io/en/latest/miniconda.html))
 
 ## How to use this tool
 
@@ -32,7 +32,7 @@ conda activate hail
 
 ### EMR `cloudformation`
 
-1. `cd` into the `hail02-on-EMR/src` folder and with the text editor of your preference open the configuration file: `hail02_EMR.yaml`. This file will be used to provide information necessary to create the cluster. Fill in the fields as necessary using your personal key and security groups (SG) information and save your changes. See configuration details below:
+1. `cd` into the `hail02-on-EMR/src` folder and with the text editor of your preference create a configuration file named `hail02_EMR.yaml`. This file will be used to provide information necessary to create the cluster. Fill in the fields as necessary using your personal key and security groups (SG) information and save your changes. See configuration details below:
 
 ```yaml
 config:
@@ -40,17 +40,16 @@ config:
   EC2_NAME_TAG: "my-hail-EMR" # Tags for the individual EC2 instances
   OWNER_TAG: "emr-owner" # EC2 owner tag
   PROJECT_TAG: "my-project" # Project tag
-  SUBPROJECT_TAG: "my-sub-project" # Sub-project tag
   REGION: "ap-southeast-1" # AWS Region tag
   S3_BUCKET: "s3n://my-s3-bucket/" # Input your project's S3 bucket
   KEY_NAME: "my-key" # Input your key name DO NOT include the .pem extension
   PATH_TO_KEY: "/full-path/to-key/" # Full path to .pem file
   MASTER_INSTANCE_TYPE: "c4.4xlarge" # Suggested EC2 instances, change as desired
-  SLAVE_INSTANCE_TYPE: "c4.4xlarge" # Suggested EC2 instances, change as desired
+  CORE_INSTANCE_TYPE: "c4.4xlarge" # Suggested EC2 instances, change as desired
   CORE_COUNT: "3" # Number of cores. Additional reference in the EC2 FAQs website
   CORE_EBS_SIZE: "150" #
   SUBNET_ID: "subnet-12345" # Select you private subnet. See the EC2 FAQs website
-  SLAVE_SECURITY_GROUP: "" # Creates a new group by default. You can also add a specific SG. See the SG link in the FAQs section
+  CORE_SECURITY_GROUP: "" # Creates a new group by default. You can also add a specific SG. See the SG link in the FAQs section
   MASTER_SECURITY_GROUP: "" # Creates a new group by default. You can also add a specific SG. See the SG link in the FAQs section
   RELEASE_LABEL: "emr-5.24.0"
 ```
@@ -82,11 +81,13 @@ tail -4 /tmp/cloudcreation_log.out | head -2
 ```
 -->
 
+<!--
 ## Launching the `JupyterNotebook` with `Hail 0.2`
 
 To launch the  `JupyterNotebook` you need the Master IP address (IPv4) that can be obtained from 1) the terminal by executing: `tail -3 /tmp/cloudcreation_log.out | head -1` or by 2) going to the AWS Management Console website and under `EC2 > Instances` selecting the corresponding `master` node then select the `description tab > Security Groups > view inbound rules`.
 
 Paste the IP in a browser followed by a `:` and port 8192: `PUBLIC_IP_ADDRESS_MASTER_NODE:8192`; use password: *`avillach`* to login. And you are all set! 
+-->
 
 ### FAQs and troubleshooting 
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # Hail 0.2 on Amazon EMR: `cloudformation` tool 
 
-This `cloudformation` tool creates an EMR cluster under an **emr-5.19.0** release using `Spark 2.3.2` and `Hadoop 2.8.3`, with  `Hail 0.2` and `JupyterNotebook` installed. 
+This `cloudformation` tool creates an EMR cluster under an **emr-5.24.0** release using `Spark 2.4.2` and `Hadoop 2.8.3`, with  `Hail 0.2` and `JupyterNotebook` installed. 
 
 ## Before using this tool (Prerequisites)
 
 This tool requires the following programs to be installed (if any of them is missing, they will be installed for you
 !): 
 
-* Python3 and pip (via Homebrew), including the necessary libraries
 * Amazon's `Command Line Interface (CLI)` utility
-* If there is no AWS account configured it will start the configuration for you. For additional help visit: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html 
+* `Conda` environment manager
 
 ## How to use this tool
 
@@ -19,28 +18,45 @@ a) **A valid EC2 key pair**. For additional details on how to create and use you
 
 b) **A configured `CLI` account**. If your `CLI` account has been previously configured, the tool will use it. If you want to re-configure a to use under a specific account or a different user, at the terminal type `aws configure`
 
+Then open your terminal and clone this repository: `git clone https://github.com/c-BIG/hail-on-EMR.git`.
+
+### Environment manager
+
+A conda environment file is shipped with the repository. It will ensure that additional dependencies are installed on your system.
+
+Create a conda environment based on `hail-on-EMR/src/conda-env.yaml` and activate it.
+
+```sh
+conda env create -f hail-on-EMR/src/conda-env.yaml
+conda activate hail
+```
+
 ### EMR `cloudformation`
 
-Open your terminal and clone this repository: `git clone https://github.com/hms-dbmi/hail-on-EMR`. 
- 
 1. `cd` into the `hail02-on-EMR/src` folder and with the text editor of your preference open the configuration file: `hail02_EMR.yaml`. This file will be used to provide information necessary to create the cluster. Fill in the fields as necessary using your personal key and security groups (SG) information and save your changes. See configuration details below:
 
 ```yaml
 config:
   EMR_CLUSTER_NAME: "my-hail-02-cluster" # Give a name to the EMR cluster
-  KEY_NAME: "my-key" # Input your key name DO NOT include the .pem extension
-  PATH_TO_KEY: "/full-path/to-key/" # Full path to .pem file
-  INSTANCE_TYPE: "c4.8xlarge" # Select the instance type, see table below. Or visit the instances types link in the FAQs section
-  CORE_COUNT: "3" # Number of cores. Additional reference in the EC2 FAQs website 
-  SUBNET_ID: "subnet-12345" # Select you private subnet. See the EC2 FAQs website
-  SLAVE_SECURITY_GROUP: "" # Creates a new group by default. You can also add a specific SG. See the SG link in the FAQs section
-  MASTER_SECURITY_GROUP: "" # Creates a new group by default. You can also add a specific SG. See the SG link in the FAQs section
   EC2_NAME_TAG: "my-hail-EMR" # Tags for the individual EC2 instances
   OWNER_TAG: "emr-owner" # EC2 owner tag
   PROJECT_TAG: "my-project" # Project tag
+  SUBPROJECT_TAG: "my-sub-project" # Sub-project tag
+  REGION: "ap-southeast-1" # AWS Region tag
   S3_BUCKET: "s3n://my-s3-bucket/" # Input your project's S3 bucket
+  KEY_NAME: "my-key" # Input your key name DO NOT include the .pem extension
+  PATH_TO_KEY: "/full-path/to-key/" # Full path to .pem file
+  MASTER_INSTANCE_TYPE: "c4.4xlarge" # Suggested EC2 instances, change as desired
+  SLAVE_INSTANCE_TYPE: "c4.4xlarge" # Suggested EC2 instances, change as desired
+  CORE_COUNT: "3" # Number of cores. Additional reference in the EC2 FAQs website
+  CORE_EBS_SIZE: "150" #
+  SUBNET_ID: "subnet-12345" # Select you private subnet. See the EC2 FAQs website
+  SLAVE_SECURITY_GROUP: "" # Creates a new group by default. You can also add a specific SG. See the SG link in the FAQs section
+  MASTER_SECURITY_GROUP: "" # Creates a new group by default. You can also add a specific SG. See the SG link in the FAQs section
+  RELEASE_LABEL: "emr-5.24.0"
 ```
-This script is defaulted to region `us-east-1`, instances `c4.8xlarge` : 3 `cores` and 1 `master`. For additional configuration details regarding the **emr-5.13.0** release, visit: <https://console.aws.amazon.com/elasticmapreduce/home?region=us-east-1#quick-create\:>. 
+
+This script is defaulted to region `ap-southeast-1`, instances `c4.4xlarge` : 3 `cores` and 1 `master`. For additional configuration details regarding the **emr-5.24.0** release, visit: <https://console.aws.amazon.com/elasticmapreduce/home?region=ap-southeast-1#quick-create\:>. 
 
 |Suggested **`INSTANCE_TYPE`s** |
 |:-------------------------:| 
@@ -57,12 +73,15 @@ This script is defaulted to region `us-east-1`, instances `c4.8xlarge` : 3 `core
 
 See additional instance details at: https://aws.amazon.com/ec2/instance-types/
 
-2. Execute the command: `sh hail_cloudformation_emr.sh`. The EMR creation takes between 5-7 minutes. The installation log file is located at `tail -f /tmp/cloudcreation_log.out`; the logs are available, under the same path, at both the local installation computer and at the master node of your EMR
-3. You can check the status of the EMR creation at: https://console.aws.amazon.com/elasticmapreduce/home?region=us-east-1. The EMR is successfully created once it gets the status `Waiting`. After created, allow ~20 minutes for all the programs to install. All the programs are installed automatically
-4. To obtain the **DNS** (to `ssh` in to the master node) and the **public IP** of the Master node (required to connect to the `JupyterNotebook`), from the terminal execute: 
+2. Execute the command: `python install2.py`. The EMR creation is initiated. The status of the cluster is monitored and will undergo from `STARTING` to `RUNNING` and `WAITING`. <!-- The EMR creation takes between 5-7 minutes. The installation log file is located at `tail -f /tmp/cloudcreation_log.out`; the logs are available, under the same path, at both the local installation computer and at the master node of your EMR -->
+3. Once the cluster is succesfully created and is `WAITING`, the installation of `HAIL` is initiated.
+<!-- You can check the status of the EMR creation at: https://console.aws.amazon.com/elasticmapreduce/home?region=ap-southeast-1. The EMR is successfully created once it gets the status `Waiting`. After created, allow ~20 minutes for all the programs to install. All the programs are installed automatically-->
+4. Once the installation of Hail is done, ssh to the master node using the `Master DNS` indicated by the script.
+<!-- To obtain the **DNS** (to `ssh` in to the master node) and the **public IP** of the Master node (required to connect to the `JupyterNotebook`), from the terminal execute: 
 ```bash
 tail -4 /tmp/cloudcreation_log.out | head -2
 ```
+-->
 
 ## Launching the `JupyterNotebook` with `Hail 0.2`
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ This `cloudformation` tool creates an EMR cluster under an **emr-5.24.0** releas
 
 ## Before using this tool (Prerequisites)
 
-This tool requires the following programs to be installed (if any of them is missing, they will be installed for you
-!): 
+This tool requires the following programs to be installed <!-- (if any of them is missing, they will be installed for you !) --> : 
 
 * Amazon's `Command Line Interface (CLI)` utility
-* `Conda` environment manager
+* `Conda` environment manager ( We suggest [Miniconda3](https://docs.conda.io/en/latest/miniconda.html))
 
 ## How to use this tool
 
@@ -74,7 +73,7 @@ This script is defaulted to region `ap-southeast-1`, instances `c4.4xlarge` : 3 
 See additional instance details at: https://aws.amazon.com/ec2/instance-types/
 
 2. Execute the command: `python install2.py`. The EMR creation is initiated. The status of the cluster is monitored and will undergo from `STARTING` to `RUNNING` and `WAITING`. <!-- The EMR creation takes between 5-7 minutes. The installation log file is located at `tail -f /tmp/cloudcreation_log.out`; the logs are available, under the same path, at both the local installation computer and at the master node of your EMR -->
-3. Once the cluster is succesfully created and is `WAITING`, the installation of `HAIL` is initiated.
+3. Once the cluster is succesfully created and is in `WAITING` status, the installation of `HAIL` is initiated.
 <!-- You can check the status of the EMR creation at: https://console.aws.amazon.com/elasticmapreduce/home?region=ap-southeast-1. The EMR is successfully created once it gets the status `Waiting`. After created, allow ~20 minutes for all the programs to install. All the programs are installed automatically-->
 4. Once the installation of Hail is done, ssh to the master node using the `Master DNS` indicated by the script.
 <!-- To obtain the **DNS** (to `ssh` in to the master node) and the **public IP** of the Master node (required to connect to the `JupyterNotebook`), from the terminal execute: 

--- a/src/EMR_deploy_and_install.py
+++ b/src/EMR_deploy_and_install.py
@@ -1,95 +1,95 @@
-#!/usr/bin/env python3
+# #!/usr/bin/env python3
 
-import boto3 #sudo python3 -m pip install boto3
-import pandas as pd
-import time
-import sys
-import botocore
-import paramiko
-import re
-import os
-import subprocess
-import yaml
+# import boto3 #sudo python3 -m pip install boto3
+# import pandas as pd
+# import time
+# import sys
+# import botocore
+# import paramiko
+# import re
+# import os
+# import subprocess
+# import yaml
 
-PATH=os.path.dirname(os.path.abspath(__file__))
+# PATH=os.path.dirname(os.path.abspath(__file__))
 
-c=yaml.load(open(PATH+"/hail02_EMR.yaml"))
+# c=yaml.load(open(PATH+"/hail02_EMR.yaml"))
 
-# Create cluster - EBS Volume 
-# command='aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin --tags \'Project='+c['config']['PROJECT_TAG']+'\' \'Owner='+c['config']['OWNER_TAG']+'\' \'Name='+c['config']['EC2_NAME_TAG']+'\' --ec2-attributes \'{"KeyName":"'+c['config']['KEY_NAME']+'","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"'+c['config']['SUBNET_ID']+'","EmrManagedSlaveSecurityGroup":"'+c['config']['SLAVE_SECURITY_GROUP']+'","EmrManagedMasterSecurityGroup":"'+c['config']['MASTER_SECURITY_GROUP']+'"}\' --service-role EMR_DefaultRole --release-label emr-5.13.0 --log-uri \''+c['config']['S3_BUCKET']+'\' --name \''+c['config']['EMR_CLUSTER_NAME']+'\' --instance-groups \'[{"InstanceCount":1,"EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":32,"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceGroupType":"MASTER","InstanceType":"'+c['config']['INSTANCE_TYPE']+'","Name":"Master Instance Group"},{"InstanceCount":'+c['config']['CORE_COUNT']+',"EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":32,"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceGroupType":"CORE","InstanceType":"'+c['config']['INSTANCE_TYPE']+'","Name":"Core Instance Group"}]\' --configurations \'[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]\' --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1'
+# # Create cluster - EBS Volume 
+# # command='aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin --tags \'Project='+c['config']['PROJECT_TAG']+'\' \'Owner='+c['config']['OWNER_TAG']+'\' \'Name='+c['config']['EC2_NAME_TAG']+'\' --ec2-attributes \'{"KeyName":"'+c['config']['KEY_NAME']+'","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"'+c['config']['SUBNET_ID']+'","EmrManagedSlaveSecurityGroup":"'+c['config']['SLAVE_SECURITY_GROUP']+'","EmrManagedMasterSecurityGroup":"'+c['config']['MASTER_SECURITY_GROUP']+'"}\' --service-role EMR_DefaultRole --release-label emr-5.13.0 --log-uri \''+c['config']['S3_BUCKET']+'\' --name \''+c['config']['EMR_CLUSTER_NAME']+'\' --instance-groups \'[{"InstanceCount":1,"EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":32,"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceGroupType":"MASTER","InstanceType":"'+c['config']['INSTANCE_TYPE']+'","Name":"Master Instance Group"},{"InstanceCount":'+c['config']['CORE_COUNT']+',"EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":32,"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceGroupType":"CORE","InstanceType":"'+c['config']['INSTANCE_TYPE']+'","Name":"Core Instance Group"}]\' --configurations \'[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]\' --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1'
 
-# Create Cluster - Instance Store
-#command=r"""aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin --tags 'project="""+c['config']['PROJECT_TAG']+"""' 'Owner="""+c['config']['OWNER_TAG']+"""' 'Name="""+c['config']['EC2_NAME_TAG']+"""' --ec2-attributes '{"KeyName":" """+c['config']['KEY_NAME']+""" ","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":" """+c['config']['SUBNET_ID']+""" ","EmrManagedSlaveSecurityGroup":" """+c['config']['SLAVE_SECURITY_GROUP']+""" ","EmrManagedMasterSecurityGroup":" """+c['config']['MASTER_SECURITY_GROUP']+""" "}' --service-role EMR_DefaultRole --enable-debugging --release-label emr-5.13.0 --log-uri '"""+c['config']['S3_BUCKET']+"""' --name '"""+c['config']['EMR_CLUSTER_NAME']+"""' --instance-groups '[{"InstanceCount":1,"InstanceGroupType":"MASTER","InstanceType":" """+c['config']['INSTANCE_TYPE']+""" ","Name":"Master Instance Group"},{"InstanceCount":"""+c['config']['CORE_COUNT']+""","InstanceGroupType":"CORE","InstanceType":" """+c['config']['INSTANCE_TYPE']+""" ","Name":"Core Instance Group"}]' --configurations '[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]' --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1"""
+# # Create Cluster - Instance Store
+# #command=r"""aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin --tags 'project="""+c['config']['PROJECT_TAG']+"""' 'Owner="""+c['config']['OWNER_TAG']+"""' 'Name="""+c['config']['EC2_NAME_TAG']+"""' --ec2-attributes '{"KeyName":" """+c['config']['KEY_NAME']+""" ","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":" """+c['config']['SUBNET_ID']+""" ","EmrManagedSlaveSecurityGroup":" """+c['config']['SLAVE_SECURITY_GROUP']+""" ","EmrManagedMasterSecurityGroup":" """+c['config']['MASTER_SECURITY_GROUP']+""" "}' --service-role EMR_DefaultRole --enable-debugging --release-label emr-5.13.0 --log-uri '"""+c['config']['S3_BUCKET']+"""' --name '"""+c['config']['EMR_CLUSTER_NAME']+"""' --instance-groups '[{"InstanceCount":1,"InstanceGroupType":"MASTER","InstanceType":" """+c['config']['INSTANCE_TYPE']+""" ","Name":"Master Instance Group"},{"InstanceCount":"""+c['config']['CORE_COUNT']+""","InstanceGroupType":"CORE","InstanceType":" """+c['config']['INSTANCE_TYPE']+""" ","Name":"Core Instance Group"}]' --configurations '[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]' --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1"""
 
-command=r"""aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin --tags 'project=chorusnpm-project' 'Owner=emr-owner' 'Name=my-hail-EMR' --ec2-attributes '{"KeyName":"chorusnpm_key","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"subnet-1760e573","EmrManagedSlaveSecurityGroup":"","EmrManagedMasterSecurityGroup":""}' --service-role EMR_DefaultRole --enable-debugging --release-label emr-5.13.0 --log-uri 's3n://npmchorus-gnomad/' --name 'my-hail-02-cluster' --instance-groups '[{"InstanceCount":1,"InstanceGroupType":"MASTER","InstanceType":"c4.2xlarge","Name":"Master Instance Group"},{"InstanceCount":3,"InstanceGroupType":"CORE","InstanceType":"c4.2xlarge","Name":"Core Instance Group"}]' --configurations '[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]' --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1"""
+# command=r"""aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin --tags 'project=chorusnpm-project' 'Owner=emr-owner' 'Name=my-hail-EMR' --ec2-attributes '{"KeyName":"chorusnpm_key","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"subnet-1760e573","EmrManagedSlaveSecurityGroup":"","EmrManagedMasterSecurityGroup":""}' --service-role EMR_DefaultRole --enable-debugging --release-label emr-5.13.0 --log-uri 's3n://npmchorus-gnomad/' --name 'my-hail-02-cluster' --instance-groups '[{"InstanceCount":1,"InstanceGroupType":"MASTER","InstanceType":"c4.2xlarge","Name":"Master Instance Group"},{"InstanceCount":3,"InstanceGroupType":"CORE","InstanceType":"c4.2xlarge","Name":"Core Instance Group"}]' --configurations '[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]' --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1"""
 
-#command='/bin/sleep 5 && echo "a"'
+# #command='/bin/sleep 5 && echo "a"'
 
-print("\n\nYour AWS CLI export command:\n")
-print(command)
+# print("\n\nYour AWS CLI export command:\n")
+# print(command)
 
-#cluster_id_json=os.popen(command).read()
-#print("a")
-#print(cluster_id_json)
-#cluster_id=cluster_id_json.split(": \"",1)[1].split("\"\n")[0]
-process=subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-if process.poll() is None:
-    print("wait")
-    process.wait()
+# #cluster_id_json=os.popen(command).read()
+# #print("a")
+# #print(cluster_id_json)
+# #cluster_id=cluster_id_json.split(": \"",1)[1].split("\"\n")[0]
+# process=subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+# if process.poll() is None:
+#     print("wait")
+#     process.wait()
 
-if process.returncode == 0:
-	print("process.returncode:"+ str(process.returncode))
-	print("Done")
+# if process.returncode == 0:
+# 	print("process.returncode:"+ str(process.returncode))
+# 	print("Done")
 
-#(stdout,stderr)=process.communicate()
-cluster_id_json=stdout
-print (cluster_id_json)
-cluster_id=cluster_id_json[0]
-print('\nClusterId: '+cluster_id+'\n')
+# #(stdout,stderr)=process.communicate()
+# cluster_id_json=stdout
+# print (cluster_id_json)
+# cluster_id=cluster_id_json[0]
+# print('\nClusterId: '+cluster_id+'\n')
 
-# Gives EMR cluster information
-client_EMR = boto3.client('emr')
+# # Gives EMR cluster information
+# client_EMR = boto3.client('emr')
 
-# Cluster state update
-status_EMR='STARTING'
-time.sleep(5)
-# Wait until the cluster is created 
-while (status_EMR!='EMPTY'):
-	print('Creating EMR...')
-	details_EMR=client_EMR.describe_cluster(ClusterId=cluster_id)
-	status_EMR=details_EMR.get('Cluster').get('Status').get('State')
-	print('Cluster status: '+status_EMR)
-	time.sleep(5)
-	if (status_EMR=='WAITING'):
-		print('Cluster successfully created! Starting HAIL installation...')
-		break
-	if (status_EMR=='TERMINATED_WITH_ERRORS'):
-		sys.exit("Cluster un-successfully created. Ending installation...")
+# # Cluster state update
+# status_EMR='STARTING'
+# time.sleep(5)
+# # Wait until the cluster is created 
+# while (status_EMR!='EMPTY'):
+# 	print('Creating EMR...')
+# 	details_EMR=client_EMR.describe_cluster(ClusterId=cluster_id)
+# 	status_EMR=details_EMR.get('Cluster').get('Status').get('State')
+# 	print('Cluster status: '+status_EMR)
+# 	time.sleep(5)
+# 	if (status_EMR=='WAITING'):
+# 		print('Cluster successfully created! Starting HAIL installation...')
+# 		break
+# 	if (status_EMR=='TERMINATED_WITH_ERRORS'):
+# 		sys.exit("Cluster un-successfully created. Ending installation...")
 
 
-# Get public DNS from master node
-master_dns=details_EMR.get('Cluster').get('MasterPublicDnsName')
-master_IP=re.sub("-",".",master_dns.split(".compute")[0].split("ec2-")[1])
+# # Get public DNS from master node
+# master_dns=details_EMR.get('Cluster').get('MasterPublicDnsName')
+# master_IP=re.sub("-",".",master_dns.split(".compute")[0].split("ec2-")[1])
 
-print('\nMaster DNS: '+ master_dns)
-print('Master IP: '+ master_IP)
+# print('\nMaster DNS: '+ master_dns)
+# print('Master IP: '+ master_IP)
 
-# Copy the key into the master
-command='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+c['config']['KEY_NAME']+'.pem '+c['config']['PATH_TO_KEY']+c['config']['KEY_NAME']+'.pem hadoop@'+master_dns+':/home/hadoop/.ssh/id_rsa'
-os.system(command)
-print('Copying keys...')
-# Copy the installation script into the master
-command='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+c['config']['KEY_NAME']+'.pem '+PATH+'/install_hail_python36.sh hadoop@'+master_dns+':/home/hadoop'
-os.system(command)
+# # Copy the key into the master
+# command='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+c['config']['KEY_NAME']+'.pem '+c['config']['PATH_TO_KEY']+c['config']['KEY_NAME']+'.pem hadoop@'+master_dns+':/home/hadoop/.ssh/id_rsa'
+# os.system(command)
+# print('Copying keys...')
+# # Copy the installation script into the master
+# command='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+c['config']['KEY_NAME']+'.pem '+PATH+'/install_hail_python36.sh hadoop@'+master_dns+':/home/hadoop'
+# os.system(command)
 
-print('Installing software...')
-key = paramiko.RSAKey.from_private_key_file(c['config']['PATH_TO_KEY']+c['config']['KEY_NAME']+'.pem')
-client = paramiko.SSHClient()
-client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-client.connect(hostname=master_IP, username="hadoop", pkey=key)
-# Execute a command(cmd) after connecting/ssh to an instance
-stdin, stdout, stderr = client.exec_command('cd /home/hadoop/')
-stdin, stdout, stderr = client.exec_command('chmod +x install_hail_python36.sh')
-stdin, stdout, stderr = client.exec_command('./install_hail_python36.sh')
-# close the client connection 
-client.close()
+# print('Installing software...')
+# key = paramiko.RSAKey.from_private_key_file(c['config']['PATH_TO_KEY']+c['config']['KEY_NAME']+'.pem')
+# client = paramiko.SSHClient()
+# client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+# client.connect(hostname=master_IP, username="hadoop", pkey=key)
+# # Execute a command(cmd) after connecting/ssh to an instance
+# stdin, stdout, stderr = client.exec_command('cd /home/hadoop/')
+# stdin, stdout, stderr = client.exec_command('chmod +x install_hail_python36.sh')
+# stdin, stdout, stderr = client.exec_command('./install_hail_python36.sh')
+# # close the client connection 
+# client.close()

--- a/src/VEP_run.sh
+++ b/src/VEP_run.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+# #!/bin/bash
 
-#Pull VEP docker image version 89.5:
-sudo docker pull ensemblorg/ensembl-vep:release_89.5
+# #Pull VEP docker image version 89.5:
+# sudo docker pull ensemblorg/ensembl-vep:release_89.5
 
-#Run VEP docker: 
-sudo docker run --name new_vep_run -t -d ensemblorg/ensembl-vep:release_89.5 tail -f /dev/null
+# #Run VEP docker: 
+# sudo docker run --name new_vep_run -t -d ensemblorg/ensembl-vep:release_89.5 tail -f /dev/null
 

--- a/src/conda-env.yaml
+++ b/src/conda-env.yaml
@@ -1,0 +1,8 @@
+name: hail
+channels:
+- conda-forge
+dependencies:
+- boto3
+- pandas
+- paramiko
+- pyyaml

--- a/src/hail_cloudformation_emr.sh
+++ b/src/hail_cloudformation_emr.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -x -e
 
-sh run.sh | tee /tmp/cloudcreation_log.out
+# sh run.sh | tee /tmp/cloudcreation_log.out

--- a/src/install2.py
+++ b/src/install2.py
@@ -63,10 +63,10 @@ def launch_emr(cluster_id, c):
     # Copy the installation script into the master
     # print('PATH:' + PATH)
     command='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem '+PATH+'/install_hail_python36.sh hadoop@'+master_dns+':/home/hadoop'
-    command2='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem '+PATH+'/jupyter_pw hadoop@'+master_dns+':/home/hadoop/'
+    # command2='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem '+PATH+'/jupyter_pw hadoop@'+master_dns+':/home/hadoop/'
     # print (command)
     os.system(command)
-    os.system(command2)
+    # os.system(command2)
 
     print('Installing software...')
     key = paramiko.RSAKey.from_private_key_file(c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem')
@@ -92,7 +92,62 @@ def main(args):
     # command='aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin --tags \'Project='+c['config']['PROJECT_TAG']+'\' \'Owner='+c['config']['OWNER_TAG']+'\' \'Name='+c['config']['EC2_NAME_TAG']+'\' --ec2-attributes \'{"KeyName":"'+c['config']['KEY_NAME']+'","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"'+c['config']['SUBNET_ID']+'","EmrManagedSlaveSecurityGroup":"'+c['config']['SLAVE_SECURITY_GROUP']+'","EmrManagedMasterSecurityGroup":"'+c['config']['MASTER_SECURITY_GROUP']+'"}\' --service-role EMR_DefaultRole --release-label emr-5.19.0 --log-uri \''+c['config']['S3_BUCKET']+'\' --name \''+c['config']['EMR_CLUSTER_NAME']+'\' --instance-groups \'[{"InstanceCount":1,"EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":32,"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceGroupType":"MASTER","InstanceType":"'+c['config']['INSTANCE_TYPE']+'","Name":"Master Instance Group"},{"InstanceCount":'+c['config']['CORE_COUNT']+',"EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":32,"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceGroupType":"CORE","InstanceType":"'+c['config']['INSTANCE_TYPE']+'","Name":"Core Instance Group"}]\' --configurations \'[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]\' --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1'
 
     # Create Cluster - Instance Store
-    command='aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin Name=JupyterHub --tags \'project='+c['config']['PROJECT_TAG']+'\' \'Owner='+c['config']['OWNER_TAG']+'\' \'Name='+c['config']['EC2_NAME_TAG']+'\' --ec2-attributes \'{"KeyName":"'+c['config']['KEY_NAME']+'","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"'+c['config']['SUBNET_ID']+'","EmrManagedSlaveSecurityGroup":"'+c['config']['SLAVE_SECURITY_GROUP']+'","EmrManagedMasterSecurityGroup":"'+c['config']['MASTER_SECURITY_GROUP']+'"}\' --service-role EMR_DefaultRole --enable-debugging --release-label \''+c['config']['RELEASE_LABEL']+'\' --log-uri \''+c['config']['S3_BUCKET']+'\' --name \''+c['config']['EMR_CLUSTER_NAME']+'\' --instance-groups \'[{"InstanceCount":1,"InstanceGroupType":"MASTER","InstanceType":"'+c['config']['MASTER_INSTANCE_TYPE']+'","Name":"Master Instance Group"},{"InstanceCount":'+c['config']['CORE_COUNT']+',"InstanceGroupType":"CORE","EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":'+c['config']['CORE_EBS_SIZE']+',"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceType":"'+c['config']['SLAVE_INSTANCE_TYPE']+'","Name":"Core Instance Group"}]\' --configurations \'[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]\' --configurations \'[{"Classification":"livy-conf","Properties":{"livy.server.session.timeout":"8h"},"Configurations":[]}]\'  --ebs-root-volume-size 32  --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region '+c['config']['REGION']
+    command=(
+        'aws emr create-cluster '
+        '--applications '
+            'Name=Ganglia '
+            'Name=Spark '
+            'Name=Zeppelin '
+            'Name=JupyterHub '
+        '--tags '
+            '\'Project='+c['config']['PROJECT_TAG']+'\' '
+            '\'Owner='+c['config']['OWNER_TAG']+'\' '
+            '\'Name='+c['config']['EC2_NAME_TAG']+'\' '
+        '--ec2-attributes \'{'
+            '"KeyName":"'+c['config']['KEY_NAME']+'",'
+            '"InstanceProfile":"EMR_EC2_DefaultRole",'
+            '"SubnetId":"'+c['config']['SUBNET_ID']+'",'
+            '"EmrManagedSlaveSecurityGroup":"'+c['config']['CORE_SECURITY_GROUP']+'",'
+            '"EmrManagedMasterSecurityGroup":"'+c['config']['MASTER_SECURITY_GROUP']+'"}\' '
+        '--service-role EMR_DefaultRole '
+        '--enable-debugging '
+        '--release-label \''+c['config']['RELEASE_LABEL']+'\' '
+        '--log-uri \''+c['config']['S3_BUCKET']+'\' '
+        '--name \''+c['config']['EMR_CLUSTER_NAME']+'\' '
+        '--instance-groups \'[{'
+            '"InstanceCount":1,'
+            '"InstanceGroupType":"MASTER",'
+            '"InstanceType":"'+c['config']['MASTER_INSTANCE_TYPE']+'",'
+            '"Name":"Master Instance Group"'
+            '},{'
+            '"InstanceCount":'+c['config']['CORE_COUNT']+','
+            '"InstanceGroupType":"CORE",'
+            '"EbsConfiguration":{'
+                '"EbsBlockDeviceConfigs":[{'
+                    '"VolumeSpecification":{'
+                        '"SizeInGB":'+c['config']['CORE_EBS_SIZE']+','
+                        '"VolumeType":"gp2"'
+                    '},'
+                    '"VolumesPerInstance":1'
+                '}]'
+            '},'
+            '"InstanceType":"'+c['config']['CORE_INSTANCE_TYPE']+'",'
+            '"Name":"Core Instance Group"'
+        '}]\' '
+        '--configurations \'[{'
+            '"Classification":"spark",'
+            '"Properties":{"maximizeResourceAllocation":"true"},'
+            '"Configurations":[]'
+        '}]\' '
+        '--configurations \'[{'
+            '"Classification":"livy-conf",'
+            '"Properties":{"livy.server.session.timeout":"8h"},'
+            '"Configurations":[]'
+        '}]\' '
+        '--ebs-root-volume-size 32  '
+        '--scale-down-behavior TERMINATE_AT_TASK_COMPLETION '
+        '--region '+c['config']['REGION']
+    )
 
     print("\n\nYour AWS CLI export command:\n")
     print(command)

--- a/src/install2.py
+++ b/src/install2.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import boto3 #sudo python3 -m pip install boto3
+import boto3
 import pandas as pd
 import time
 import sys
@@ -19,7 +19,7 @@ PATH=os.path.dirname(os.path.abspath(__file__))
 def launch_emr(cluster_id, c):
     # cluster_id_json=os.popen(command).read()
     # cluster_id=cluster_id_json.split(": \"",1)[1].split("\"\n")[0]
-    #print('\nClusterId: '+cluster_id+'\n')
+    # print('\nClusterId: '+cluster_id+'\n')
 
     # Gives EMR cluster information
     client_EMR = boto3.client('emr')
@@ -43,7 +43,7 @@ def launch_emr(cluster_id, c):
 
     # Get public DNS from master node
     master_dns=details_EMR.get('Cluster').get('MasterPublicDnsName')
-    #master_IP=re.sub("-",".",master_dns.split(".compute")[0].split("ec2-")[1])
+    # master_IP=re.sub("-",".",master_dns.split(".compute")[0].split("ec2-")[1])
     master_IP=re.sub("-",".",master_dns.split(".compute")[0].split("ec2-")[1].split('.')[0])
 
     print('\nMaster DNS: '+ master_dns)
@@ -96,8 +96,8 @@ def main(args):
 
     print("\n\nYour AWS CLI export command:\n")
     print(command)
-    print('args.clusterid:' )
-    print(args.clusterid)
+    # print('args.clusterid:' )
+    # print(args.clusterid)
 
     if args.clusterid:
        cluster_id = args.clusterid
@@ -116,7 +116,7 @@ def main(args):
 
         cluster_id = cluster_id_byte.decode("utf-8").rstrip()
 
-    print(cluster_id)
+    print('Cluster ID: '+ cluster_id)
 
     launch_emr(cluster_id, c)
 

--- a/src/install2.py
+++ b/src/install2.py
@@ -49,21 +49,22 @@ def launch_emr(cluster_id, c):
     print('\nMaster DNS: '+ master_dns)
     print('Master IP: '+ master_IP)
 
+    print('Copying keys...')
     # Copy the key into the master
     command='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem hadoop@'+master_dns+':/home/hadoop/.ssh/id_rsa'
-    print (command)
+    # print (command)
     os.system(command)
 
     command='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem hadoop@'+master_dns+':/home/hadoop/'+ c['config']['KEY_NAME'] + '.pem'
-    print (command)
+    # print (command)
     os.system(command)
 
-    print('Copying keys...')
+    print('Copying installation script...')
     # Copy the installation script into the master
-    print('PATH:' + PATH)
+    # print('PATH:' + PATH)
     command='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem '+PATH+'/install_hail_python36.sh hadoop@'+master_dns+':/home/hadoop'
     command2='scp -o \'StrictHostKeyChecking no\' -i '+c['config']['PATH_TO_KEY']+ '/' + c['config']['KEY_NAME']+'.pem '+PATH+'/jupyter_pw hadoop@'+master_dns+':/home/hadoop/'
-    print (command)
+    # print (command)
     os.system(command)
     os.system(command2)
 
@@ -80,16 +81,18 @@ def launch_emr(cluster_id, c):
     # close the client connection
     client.close()
 
+    # END
+    print('DONE')
 
 def main(args):
 
-    c=yaml.load(open(PATH+"/hail02_EMR.yaml"))
+    c=yaml.load(open(PATH+"/hail02_EMR.yaml"), Loader=yaml.BaseLoader)
 
     # Create cluster - EBS Volume
     # command='aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin --tags \'Project='+c['config']['PROJECT_TAG']+'\' \'Owner='+c['config']['OWNER_TAG']+'\' \'Name='+c['config']['EC2_NAME_TAG']+'\' --ec2-attributes \'{"KeyName":"'+c['config']['KEY_NAME']+'","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"'+c['config']['SUBNET_ID']+'","EmrManagedSlaveSecurityGroup":"'+c['config']['SLAVE_SECURITY_GROUP']+'","EmrManagedMasterSecurityGroup":"'+c['config']['MASTER_SECURITY_GROUP']+'"}\' --service-role EMR_DefaultRole --release-label emr-5.19.0 --log-uri \''+c['config']['S3_BUCKET']+'\' --name \''+c['config']['EMR_CLUSTER_NAME']+'\' --instance-groups \'[{"InstanceCount":1,"EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":32,"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceGroupType":"MASTER","InstanceType":"'+c['config']['INSTANCE_TYPE']+'","Name":"Master Instance Group"},{"InstanceCount":'+c['config']['CORE_COUNT']+',"EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":32,"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceGroupType":"CORE","InstanceType":"'+c['config']['INSTANCE_TYPE']+'","Name":"Core Instance Group"}]\' --configurations \'[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]\' --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1'
 
     # Create Cluster - Instance Store
-    command='aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin Name=JupyterHub --tags \'project='+c['config']['PROJECT_TAG']+'\' \'Owner='+c['config']['OWNER_TAG']+'\' \'Name='+c['config']['EC2_NAME_TAG']+'\' --ec2-attributes \'{"KeyName":"'+c['config']['KEY_NAME']+'","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"'+c['config']['SUBNET_ID']+'","EmrManagedSlaveSecurityGroup":"'+c['config']['SLAVE_SECURITY_GROUP']+'","EmrManagedMasterSecurityGroup":"'+c['config']['MASTER_SECURITY_GROUP']+'"}\' --service-role EMR_DefaultRole --enable-debugging --release-label \''+c['config']['RELEASE_LABEL']+'\' --log-uri \''+c['config']['S3_BUCKET']+'\' --name \''+c['config']['EMR_CLUSTER_NAME']+'\' --instance-groups \'[{"InstanceCount":1,"InstanceGroupType":"MASTER","InstanceType":"'+c['config']['MASTER_INSTANCE_TYPE']+'","Name":"Master Instance Group"},{"InstanceCount":'+c['config']['CORE_COUNT']+',"InstanceGroupType":"CORE","EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":'+c['config']['CORE_EBS_SIZE']+',"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceType":"'+c['config']['CORE_INSTANCE_TYPE']+'","Name":"Core Instance Group"}]\' --configurations \'[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]\' --configurations \'[{"Classification":"livy-conf","Properties":{"livy.server.session.timeout":"8h"},"Configurations":[]}]\'  --ebs-root-volume-size 32  --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region ap-southeast-1'
+    command='aws emr create-cluster --applications Name=Ganglia Name=Spark Name=Zeppelin Name=JupyterHub --tags \'project='+c['config']['PROJECT_TAG']+'\' \'Owner='+c['config']['OWNER_TAG']+'\' \'Name='+c['config']['EC2_NAME_TAG']+'\' --ec2-attributes \'{"KeyName":"'+c['config']['KEY_NAME']+'","InstanceProfile":"EMR_EC2_DefaultRole","SubnetId":"'+c['config']['SUBNET_ID']+'","EmrManagedSlaveSecurityGroup":"'+c['config']['SLAVE_SECURITY_GROUP']+'","EmrManagedMasterSecurityGroup":"'+c['config']['MASTER_SECURITY_GROUP']+'"}\' --service-role EMR_DefaultRole --enable-debugging --release-label \''+c['config']['RELEASE_LABEL']+'\' --log-uri \''+c['config']['S3_BUCKET']+'\' --name \''+c['config']['EMR_CLUSTER_NAME']+'\' --instance-groups \'[{"InstanceCount":1,"InstanceGroupType":"MASTER","InstanceType":"'+c['config']['MASTER_INSTANCE_TYPE']+'","Name":"Master Instance Group"},{"InstanceCount":'+c['config']['CORE_COUNT']+',"InstanceGroupType":"CORE","EbsConfiguration":{"EbsBlockDeviceConfigs":[{"VolumeSpecification":{"SizeInGB":'+c['config']['CORE_EBS_SIZE']+',"VolumeType":"gp2"},"VolumesPerInstance":1}]},"InstanceType":"'+c['config']['SLAVE_INSTANCE_TYPE']+'","Name":"Core Instance Group"}]\' --configurations \'[{"Classification":"spark","Properties":{"maximizeResourceAllocation":"true"},"Configurations":[]}]\' --configurations \'[{"Classification":"livy-conf","Properties":{"livy.server.session.timeout":"8h"},"Configurations":[]}]\'  --ebs-root-volume-size 32  --scale-down-behavior TERMINATE_AT_TASK_COMPLETION --region '+c['config']['REGION']
 
     print("\n\nYour AWS CLI export command:\n")
     print(command)
@@ -103,16 +106,17 @@ def main(args):
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
 
         cluster_id_byte = process.stdout.read()
-        cluster_id_json = cluster_id_byte.decode("utf-8")
-        cluster_id_dict = {}
-        cluster_id_dict = ast.literal_eval(cluster_id_json)
+        # cluster_id_json = cluster_id_byte.decode("utf-8")
+        # cluster_id_dict = {}
+        # print(cluster_id_json)
+        # cluster_id_dict = cluster_id_json
+        # print("cluster_id_dict")
+        # print( cluster_id_dict)
+        # cluster_id = cluster_id_dict["ClusterId"]
 
-        print("cluster_id_dict")
-        print( cluster_id_dict)
-        cluster_id = cluster_id_dict["ClusterId"]
+        cluster_id = cluster_id_byte.decode("utf-8").rstrip()
 
-
-    print( cluster_id)
+    print(cluster_id)
 
     launch_emr(cluster_id, c)
 

--- a/src/jupyter_build.sh
+++ b/src/jupyter_build.sh
@@ -1,48 +1,48 @@
-#!/bin/bash
+# #!/bin/bash
 
-export SPARK_HOME=/usr/lib/spark
-export PYSPARK_PYTHON=python3
+# export SPARK_HOME=/usr/lib/spark
+# export PYSPARK_PYTHON=python3
 
-export PYTHONPATH="/home/hadoop/hail-python.zip:$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-src.zip"
-echo "PYTHONPATH: ${PYTHONPATH}"
+# export PYTHONPATH="/home/hadoop/hail-python.zip:$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-src.zip"
+# echo "PYTHONPATH: ${PYTHONPATH}"
 
-export PYSPARK_PYTHON=python3
-echo "PYSPARK_PYTHON: ${PYSPARK_PYTHON}"
+# export PYSPARK_PYTHON=python3
+# echo "PYSPARK_PYTHON: ${PYSPARK_PYTHON}"
 
-export ASSEMBLY_JAR=`ls /usr/share/aws/emr/emrfs/lib/emrfs-hadoop-assembly*`
-echo $ASSEMBLY_JAR
-JAR_PATH="/home/hadoop/hail-all-spark.jar:${ASSEMBLY_JAR}"
-echo $JAR_PATH
-export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath='$JAR_PATH' --conf spark.executor.extraClassPath='$JAR_PATH' pyspark-shell"
-echo "PYSPARK_SUBMIT_ARGS: ${PYSPARK_SUBMIT_ARGS}"
+# export ASSEMBLY_JAR=`ls /usr/share/aws/emr/emrfs/lib/emrfs-hadoop-assembly*`
+# echo $ASSEMBLY_JAR
+# JAR_PATH="/home/hadoop/hail-all-spark.jar:${ASSEMBLY_JAR}"
+# echo $JAR_PATH
+# export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath='$JAR_PATH' --conf spark.executor.extraClassPath='$JAR_PATH' pyspark-shell"
+# echo "PYSPARK_SUBMIT_ARGS: ${PYSPARK_SUBMIT_ARGS}"
 
-export JUPYTER_PASSWORD=`cat /home/hadoop/jupyter_pw`
-echo $JUPYTER_PASSWORD
-# In case this is a repeated run
-sudo userdel jupyter
-sudo rm -fR /mnt/incubator-toree
-sudo rm -fR /etc/sbt/conf
+# export JUPYTER_PASSWORD=`cat /home/hadoop/jupyter_pw`
+# echo $JUPYTER_PASSWORD
+# # In case this is a repeated run
+# sudo userdel jupyter
+# sudo rm -fR /mnt/incubator-toree
+# sudo rm -fR /etc/sbt/conf
 
-# Run the installer
-#./jupyter_installer.sh \
-#	# --r \
-#	--spark-version "2.3.2" \
-#	--toree \
-#	--ds-packages \
-#	--password "avillach" \
-#	--port 8192 \
-#	--s3fs \
-#	--spark-opts "--jars ${JAR_PATH} --py-files /home/hadoop/hail-python.zip"
+# # Run the installer
+# #./jupyter_installer.sh \
+# #	# --r \
+# #	--spark-version "2.3.2" \
+# #	--toree \
+# #	--ds-packages \
+# #	--password "avillach" \
+# #	--port 8192 \
+# #	--s3fs \
+# #	--spark-opts "--jars ${JAR_PATH} --py-files /home/hadoop/hail-python.zip"
 
-# Run the installer
-./jupyter_installer.sh \
-        --spark-version "2.4.2" \
-        --toree \
-        --ds-packages \
-        --password "avillach" \
-        --port 8192 \
-        --s3fs \
-        --spark-opts "--jars ${JAR_PATH} --py-files /home/hadoop/hail-python.zip"
+# # Run the installer
+# ./jupyter_installer.sh \
+#         --spark-version "2.4.2" \
+#         --toree \
+#         --ds-packages \
+#         --password "avillach" \
+#         --port 8192 \
+#         --s3fs \
+#         --spark-opts "--jars ${JAR_PATH} --py-files /home/hadoop/hail-python.zip"
 
 	
-# ./jupyter_extraRlibraries_install.sh # Not necessary as they are defined in the jupyter_installer.sh
+# # ./jupyter_extraRlibraries_install.sh # Not necessary as they are defined in the jupyter_installer.sh

--- a/src/jupyter_extraRlibraries_install.sh
+++ b/src/jupyter_extraRlibraries_install.sh
@@ -1,17 +1,17 @@
-#!/bin/bash
+# #!/bin/bash
 
-echo "Installing additional R libraries"
-sudo R --no-save << R_SCRIPT
+# echo "Installing additional R libraries"
+# sudo R --no-save << R_SCRIPT
 
-paket <- function(pak){
-  new_pak <- pak[!(pak %in% rownames(installed.packages()))]
-  if (length(new_pak)) 
-    install.packages(new_pak, dependencies = TRUE)
-  sapply(pak, library, character.only = TRUE)
-}
+# paket <- function(pak){
+#   new_pak <- pak[!(pak %in% rownames(installed.packages()))]
+#   if (length(new_pak)) 
+#     install.packages(new_pak, dependencies = TRUE)
+#   sapply(pak, library, character.only = TRUE)
+# }
 
-listOfPackages <- c("devtools","XML","readr","httr","RCurl","data.table","parallel","tidyverse","dplyr","knitr","gplots","tidyr","reshape","shiny","ggplot2","rlist","ggthemes","lubridate","Rcpp","reshape")
+# listOfPackages <- c("devtools","XML","readr","httr","RCurl","data.table","parallel","tidyverse","dplyr","knitr","gplots","tidyr","reshape","shiny","ggplot2","rlist","ggthemes","lubridate","Rcpp","reshape")
 
-paket(listOfPackages)
+# paket(listOfPackages)
 
-R_SCRIPT
+# R_SCRIPT

--- a/src/jupyter_installer.sh
+++ b/src/jupyter_installer.sh
@@ -1,1082 +1,1082 @@
-#!/bin/bash
-#
-# Copyright 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Amazon Software License (the "License").
-# You may not use this file except in compliance with the License.
-# A copy of the License is located at
-#
-# http://aws.amazon.com/asl/
-#
-# or in the "license" file accompanying this file. This file is distributed
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-# express or implied. See the License for the specific language governing
-# permissions and limitations under the License.
+# #!/bin/bash
+# #
+# # Copyright 2016-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# #
+# # Licensed under the Amazon Software License (the "License").
+# # You may not use this file except in compliance with the License.
+# # A copy of the License is located at
+# #
+# # http://aws.amazon.com/asl/
+# #
+# # or in the "license" file accompanying this file. This file is distributed
+# # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# # express or implied. See the License for the specific language governing
+# # permissions and limitations under the License.
 
-set -x -e
+# set -x -e
 
-# AWS EMR bootstrap script 
-# for installing Jupyter notebook on AWS EMR 5+
-#
-# 2016-11-04 - Tom Zeng tomzeng@amazon.com, initial version
-# 2016-11-20 - Tom Zeng, add JupyterHub
-# 2016-12-01 - Tom Zeng, add s3 support and cached install
-# 2016-12-03 - Tom Zeng, use puppet to install/run services
-# 2016-12-06 - Tom Zeng, switch to s3fs for S3 support since s3nb is not fully working
-# 2016-12-29 - Tom Zeng, add Dask and Dask.distributed
-# 2017-04-18 - Tom Zeng, add BigDL support
-# 2017-05-16 = Tom Zeng, add cached install for EMR 5.5, updated yum rpm cache and miniCRAN
-# 2017-05-20 - Tom Zeng, add s3contents to replace s3nb which no longer works due to Jupyter update
-# 2017-05-23 - Tom Zeng, fix the s3contents dummy last_modified field
-# 2017-05-25 - Tom Zeng, turn off tensorflow, pip wheel install no longer working, will fix later
-# 2017-06-09 - Tom Zeng, fix install issue for EMR 5.6 caused by kernel source package already installed
-# 2017-11-29 - Tom Zeng, fix the broken JavaScript and CoffeeScript kernels, now works on EMR 5.10
-# 2018-03-02 - Tom Zeng, fix the python package (six) conflict for 'sudo jupyter contrib nbextension install --system'
-# 2018-03-06 - Tom Zeng, fix the latest tornado (5.0) and asyncio package conflict by using tornadio 4.5.3
-# 2018-03-08 - Tom Zeng, upgrade Julia from 0.5 to 0.6.2, upgrade MXNet to the latest available version, upgrade Ruby to 2.5.0
-# 2018-03-09 - Tom Zeng, upgrade TensorFlow to 1.6, add SageMaker to --ml-packages
-# 2018-04-12 - Tom Zeng, fixed JupyterHub s3 storage, it works only with --s3fs, each user's notebooks are stored in s://<bucket>/<folder>/<user>
-
-
-#
-# Usage:
-# --r - install the IRKernel for R (Sparklyr is installed with this option, but as of 2017-04-05 Sparklyr does not support Spark 2.x yet)
-# --toree - install the Apache Toree kernel that supports Scala, PySpark, SQL, SparkR for Apache Spark
-# --interpreters - specify Apache Toree interpreters, default is all: "Scala,SQL,PySpark,SparkR"
-# --julia - install the IJulia kernel for Julia
-# --bigdl - install Intel's BigDL Deep Learning framework
-# --ruby - install the iRuby kernel for Ruby
-# --torch - intall the iTorch kernel for Torch
-# --javascript - install the JavaScript and CoffeeScript kernels (only works for JupyterHub for now)
-# --dask - install Dask and Dask.distributed, with the scheduler on master instance and the workers on the slave instances
-# --ds-packages - install the Python Data Science related packages (scikit-learn pandas numpy numexpr statsmodels seaborn)
-# --ml-packages - install the Python Machine Learning related packages (theano keras tensorflow)
-# --python-packages - install specific python packages e.g. "ggplot nilean"
-# --port - set the port for Jupyter notebook, default is 8888
-# --user - create a default user for Jupyterhub
-# --password - set the password for Jupyter notebook and JupyterHub
-# --localhost-only - restrict jupyter to listen on localhost only, default to listen on all ip addresses for the instance
-# --jupyterhub - install JupyterHub
-# --jupyterhub-port - set the port for JupyterHub, default is 8000
-# --no-jupyter - if JupyterHub is installed, use this to disable Jupyter
-# --no-jupyterhub - if Jupyter is installed, use this to disable JupyterHub
-# --notebook-dir - specify notebook folder, this could be a local directory or a S3 bucket
-# --cached-install - use some cached dependency artifacts on s3 to speed up installation
-# --ssl - enable ssl, make sure to use your own cert and key files to get rid of the warning
-# --copy-samples - copy sample notebooks to samples sub folder under the notebook folder
-# --spark-opts - user supplied Spark options to pass to SPARK_OPTS
-# --s3fs - use s3fs instead of s3contents(default) for storing notebooks on s3, s3fs could cause slowness if the s3 bucket has lots of file
-# --python3 - install python 3 packages and use python3
-
-# check for master node
-IS_MASTER=false
-if grep isMaster /mnt/var/lib/info/instance.json | grep true;
-then
-  IS_MASTER=true
-fi
-
-# error message
-error_msg ()
-{
-  echo 1>&2 "Error: $1"
-}
-
-# some defaults
-RUBY_KERNEL=false
-R_KERNEL=true
-JULIA_KERNEL=false
-TOREE_KERNEL=true
-TORCH_KERNEL=false
-DS_PACKAGES=false
-ML_PACKAGES=false
-PYTHON_PACKAGES="pyserial oauth cheetah argparse PrettyTable wheel pandas parsimonious tornado jupyter numpy collections math pprint bokeh scikit-learn matplotlib ggplot"
-RUN_AS_STEP=false
-NOTEBOOK_DIR=""
-NOTEBOOK_DIR_S3=false
-JUPYTER_PORT=8192
-JUPYTER_PASSWORD=""
-JUPYTER_LOCALHOST_ONLY=false
-PYTHON3=true
-GPU=false
-CPU_GPU="cpu"
-GPUU=""
-JUPYTER_HUB=false
-JUPYTER_HUB_PORT=8007
-JUPYTER_HUB_IP="*"
-JUPYTER_HUB_DEFAULT_USER="jupyter"
-INTERPRETERS="Scala,SQL,PySpark,SparkR"
-R_REPOS_LOCAL="file:////mnt/miniCRAN"
-R_REPOS_REMOTE="https://cran.r-project.org"
-USE_CACHED_DEPS=false
-R_REPOS=$R_REPOS_REMOTE
-SSL=false
-SSL_OPTS="--no-ssl"
-COPY_SAMPES=false
-USER_SPARK_OPTS=""
-NOTEBOOK_DIR_S3_S3NB=false
-NOTEBOOK_DIR_S3_S3CONTENTS=true
-JS_KERNEL=false
-NO_JUPYTER=false
-INSTALL_DASK=false
-INSTALL_PY3_PKGS=true
-APACHE_SPARK_VERSION="2.4.2"
-BIGDL=false
-MXNET=false
-DL4J=false
-NPROC=$(nproc)
-UPDATE_FLAG=""
-USE_SSE=false
-KMS_ID=""
-
-# get input parameters
-while [ $# -gt 0 ]; do
-    case "$1" in
-    --r)
-      R_KERNEL=true
-      ;;
-    --julia)
-      JULIA_KERNEL=true
-      ;;
-    --toree)
-      TOREE_KERNEL=true
-      ;;
-    --torch)
-      TORCH_KERNEL=true
-      ;;
-    --javascript)
-      JS_KERNEL=true
-      ;;
-    --ds-packages)
-      DS_PACKAGES=true
-      ;;
-    --ml-packages)
-      ML_PACKAGES=true
-      ;;
-    --python-packages)
-      shift
-      PYTHON_PACKAGES=$1
-      ;;
-    --bigdl)
-      BIGDL=true
-      ;;
-    --mxnet)
-      MXNET=true
-      ;;
-    --dl4j)
-      DL4J=true
-      ;;
-    --ruby)
-      RUBY_KERNEL=true
-      ;;
-    --gpu)
-      GPU=true
-      CPU_GPU="gpu"
-      GPUU="_gpu"
-      ;;
-    --run-as-step)
-      RUN_AS_STEP=true
-      ;;
-    --port)
-      shift
-      JUPYTER_PORT=$1
-      ;;
-    --user)
-      shift
-      JUPYTER_HUB_DEFAULT_USER=$1
-      ;;
-    --password)
-      shift
-      JUPYTER_PASSWORD=$1
-      ;;
-    --localhost-only)
-      JUPYTER_LOCALHOST_ONLY=true
-      JUPYTER_HUB_IP=""
-      ;;
-    --jupyterhub)
-      JUPYTER_HUB=true
-      #PYTHON3=true
-      ;;
-    --jupyterhub-port)
-      shift
-      JUPYTER_HUB_PORT=$1
-      ;;
-    --notebook-dir)
-      shift
-      NOTEBOOK_DIR=$1
-      ;;
-    --copy-samples)
-      COPY_SAMPLES=true
-      ;;
-    --toree-interpreters)
-      shift
-      INTERPRETERS=$1
-      ;;
-    --cached-install)
-      USE_CACHED_DEPS=true
-      #R_REPOS=$R_REPOS_LOCAL
-      ;;
-    --no-cached-install)
-      USE_CACHED_DEPS=false
-      R_REPOS=$R_REPOS_REMOTE
-      ;;
-    --no-jupyter)
-      NO_JUPYTER=true
-      ;;
-    --no-jupyterhub)
-      JUPYTER_HUB=false
-      ;;
-    --ssl)
-      SSL=true
-      ;;
-    --update-python-packages)
-      UPDATE_FLAG="-U"
-      ;;
-    --dask)
-      INSTALL_DASK=true
-      ;;
-    --python3)
-      INSTALL_PY3_PKGS=true
-      ;;
-    --spark-opts)
-      shift
-      USER_SPARK_OPTS=$1
-      ;;
-    --spark-version)
-      shift
-      APACHE_SPARK_VERSION=$1
-      ;;
-    --s3fs)
-      #NOTEBOOK_DIR_S3_S3NB=false
-      NOTEBOOK_DIR_S3_S3CONTENTS=true
-      ;;
-    --use-sse)
-      USE_SSE=true
-      ;;
-    --kms-id)
-      shift
-      KMS_ID=$1
-      ;;
-    #--s3nb) # this stopped working after Jupyter update in early 2017
-    #  NOTEBOOK_DIR_S3_S3NB=true
-    #  ;;
-    -*)
-      # do not exit out, just note failure
-      error_msg "unrecognized option: $1"
-      ;;
-    *)
-      break;
-      ;;
-    esac
-    shift
-done
-
-echo '### JUPYTER_INSTALLER.SH ###'
+# # AWS EMR bootstrap script 
+# # for installing Jupyter notebook on AWS EMR 5+
+# #
+# # 2016-11-04 - Tom Zeng tomzeng@amazon.com, initial version
+# # 2016-11-20 - Tom Zeng, add JupyterHub
+# # 2016-12-01 - Tom Zeng, add s3 support and cached install
+# # 2016-12-03 - Tom Zeng, use puppet to install/run services
+# # 2016-12-06 - Tom Zeng, switch to s3fs for S3 support since s3nb is not fully working
+# # 2016-12-29 - Tom Zeng, add Dask and Dask.distributed
+# # 2017-04-18 - Tom Zeng, add BigDL support
+# # 2017-05-16 = Tom Zeng, add cached install for EMR 5.5, updated yum rpm cache and miniCRAN
+# # 2017-05-20 - Tom Zeng, add s3contents to replace s3nb which no longer works due to Jupyter update
+# # 2017-05-23 - Tom Zeng, fix the s3contents dummy last_modified field
+# # 2017-05-25 - Tom Zeng, turn off tensorflow, pip wheel install no longer working, will fix later
+# # 2017-06-09 - Tom Zeng, fix install issue for EMR 5.6 caused by kernel source package already installed
+# # 2017-11-29 - Tom Zeng, fix the broken JavaScript and CoffeeScript kernels, now works on EMR 5.10
+# # 2018-03-02 - Tom Zeng, fix the python package (six) conflict for 'sudo jupyter contrib nbextension install --system'
+# # 2018-03-06 - Tom Zeng, fix the latest tornado (5.0) and asyncio package conflict by using tornadio 4.5.3
+# # 2018-03-08 - Tom Zeng, upgrade Julia from 0.5 to 0.6.2, upgrade MXNet to the latest available version, upgrade Ruby to 2.5.0
+# # 2018-03-09 - Tom Zeng, upgrade TensorFlow to 1.6, add SageMaker to --ml-packages
+# # 2018-04-12 - Tom Zeng, fixed JupyterHub s3 storage, it works only with --s3fs, each user's notebooks are stored in s://<bucket>/<folder>/<user>
 
 
-sudo bash -c 'echo "fs.file-max = 25129162" >> /etc/sysctl.conf'
-sudo sysctl -p /etc/sysctl.conf
-sudo bash -c 'echo "* soft    nofile          1048576" >> /etc/security/limits.conf'
-sudo bash -c 'echo "* hard    nofile          1048576" >> /etc/security/limits.conf'
-sudo bash -c 'echo "session    required   pam_limits.so" >> /etc/pam.d/su'
+# #
+# # Usage:
+# # --r - install the IRKernel for R (Sparklyr is installed with this option, but as of 2017-04-05 Sparklyr does not support Spark 2.x yet)
+# # --toree - install the Apache Toree kernel that supports Scala, PySpark, SQL, SparkR for Apache Spark
+# # --interpreters - specify Apache Toree interpreters, default is all: "Scala,SQL,PySpark,SparkR"
+# # --julia - install the IJulia kernel for Julia
+# # --bigdl - install Intel's BigDL Deep Learning framework
+# # --ruby - install the iRuby kernel for Ruby
+# # --torch - intall the iTorch kernel for Torch
+# # --javascript - install the JavaScript and CoffeeScript kernels (only works for JupyterHub for now)
+# # --dask - install Dask and Dask.distributed, with the scheduler on master instance and the workers on the slave instances
+# # --ds-packages - install the Python Data Science related packages (scikit-learn pandas numpy numexpr statsmodels seaborn)
+# # --ml-packages - install the Python Machine Learning related packages (theano keras tensorflow)
+# # --python-packages - install specific python packages e.g. "ggplot nilean"
+# # --port - set the port for Jupyter notebook, default is 8888
+# # --user - create a default user for Jupyterhub
+# # --password - set the password for Jupyter notebook and JupyterHub
+# # --localhost-only - restrict jupyter to listen on localhost only, default to listen on all ip addresses for the instance
+# # --jupyterhub - install JupyterHub
+# # --jupyterhub-port - set the port for JupyterHub, default is 8000
+# # --no-jupyter - if JupyterHub is installed, use this to disable Jupyter
+# # --no-jupyterhub - if Jupyter is installed, use this to disable JupyterHub
+# # --notebook-dir - specify notebook folder, this could be a local directory or a S3 bucket
+# # --cached-install - use some cached dependency artifacts on s3 to speed up installation
+# # --ssl - enable ssl, make sure to use your own cert and key files to get rid of the warning
+# # --copy-samples - copy sample notebooks to samples sub folder under the notebook folder
+# # --spark-opts - user supplied Spark options to pass to SPARK_OPTS
+# # --s3fs - use s3fs instead of s3contents(default) for storing notebooks on s3, s3fs could cause slowness if the s3 bucket has lots of file
+# # --python3 - install python 3 packages and use python3
 
-sudo puppet module install spantree-upstart
-
-RELEASE=$(cat /etc/system-release)
-REL_NUM=$(ruby -e "puts '$RELEASE'.split.last")
-
-echo ### ${USE_CACHED_DEPS} ###
-if [ "$USE_CACHED_DEPS" = true ]; then
-  cd /mnt
-  aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/jupyter-deps.zip .
-  aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/yum-rpm-cache-$REL_NUM.zip .
-  unzip jupyter-deps.zip
-  unzip yum-rpm-cache-$REL_NUM.zip
-  rm jupyter-deps.zip
-  rm yum-rpm-cache-$REL_NUM.zip
-fi
-
-echo ### ${R_REPOS} = ${R_REPOS_LOCAL} ###
-if [ "$R_REPOS" = "$R_REPOS_LOCAL" ]; then
-  cd /mnt
-  #aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/miniCRAN-20170516.zip miniCRAN.zip
-  aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/miniCRAN.zip miniCRAN.zip
-  unzip miniCRAN.zip
-  rm miniCRAN.zip
-fi
-
-# sudo mkdir -p /mnt/var/aws/emr
-# sudo cp -pr /var/aws/emr/packages /mnt/var/aws/emr/ && sudo rm -rf /var/aws/emr/packages && sudo mkdir /var/aws/emr/packages && sudo mount -o bind /mnt/var/aws/emr/packages /var/aws/emr/packages &
-
-# # move /usr/local and usr/share to /mnt/usr-moved/ to avoid running out of space on /
-# if [ ! -d /mnt/usr-moved ]; then
-#   echo "move local start" >> /tmp/install_time.log
-#   date >> /tmp/install_time.log
-#   sudo mkdir /mnt/usr-moved
-#   sudo mv /usr/local /mnt/usr-moved/ && sudo ln -s /mnt/usr-moved/local /usr/
-#   echo "move local end, move share start" >> /tmp/install_time.log
-#   date >> /tmp/install_time.log
-#   sudo mv /usr/share /mnt/usr-moved/ && sudo ln -s /mnt/usr-moved/share /usr/
-#   echo "move share end" >> /tmp/install_time.log
-#   date >> /tmp/install_time.log
+# # check for master node
+# IS_MASTER=false
+# if grep isMaster /mnt/var/lib/info/instance.json | grep true;
+# then
+#   IS_MASTER=true
 # fi
 
-export MAKE="make -j $NPROC"
-
-echo ### ${USE_CACHED_DEPS} ###
-sudo yum remove -y kernel-4.9.27-14.31.amzn1.x86_64 # EMR 5.6
-if [ "$USE_CACHED_DEPS" = true ]; then
-  sudo yum install -y libcurl-devel # workaround for EMR 5.9 until libcurl cache is fixed
-  sudo yum install --skip-broken -y /mnt/yum-rpm-cache/*
-else
-  sudo yum install -y xorg-x11-xauth.x86_64 xorg-x11-server-utils.x86_64 xterm libXt libX11-devel libXt-devel libcurl libcurl-devel git graphviz cyrus-sasl cyrus-sasl-devel readline readline-devel gnuplot
-  sudo yum install --enablerepo=epel -y nodejs npm zeromq3 zeromq3-devel
-  sudo npm config set strict-ssl false
-  sudo npm config set registry http://registry.npmjs.org/
-  sudo yum install -y gcc-c++ patch zlib zlib-devel
-  sudo  yum install -y libyaml-devel libffi-devel openssl-devel make
-  sudo yum install -y bzip2 autoconf automake libtool bison iconv-devel sqlite-devel
-fi
-
-echo ### ${PYTHON3} ###
-cd /mnt
-PYTHON3=false
-if [ "$PYTHON3" = true ]; then # this will break bigtop/puppet which relies on python 2, so disable with the line above
-  export PYSPARK_PYTHON="python3"
-  sudo python3 -m pip install --upgrade pip
-  if [ -f /usr/bin/python3.4 ]; then
-    sudo ln -sf /usr/bin/python3.4 /usr/bin/python
-  fi
-  if [ -f /usr/bin/pip-3.4 ]; then
-    sudo ln -sf /usr/bin/pip-3.4 /usr/bin/pip
-  fi
-else
-  sudo python -m pip install --upgrade pip
-  if [ -f /usr/bin/pip-2.7 ]; then
-    sudo ln -sf /usr/bin/pip-2.7 /usr/bin/pip
-  fi
-fi
-
-echo ### ${JS_KERNEL} ###
-export NODE_PATH='/usr/lib/node_modules'
-if [ "$JS_KERNEL" = true ]; then
-  sudo python -m pip install jinja2 tornado jsonschema pyzmq
-  # the following no longer working or needed on the latest EMR version 5.10
-  #sudo npm cache clean -f
-  #sudo npm install -g npm
-  #sudo npm install -g n
-  #sudo n stable
-fi
-
-TF_BINARY_URL_PY3="https://storage.googleapis.com/tensorflow/linux/$CPU_GPU/tensorflow$GPUU-1.6.0-cp34-cp34m-linux_x86_64.whl"
-TF_BINARY_URL="https://storage.googleapis.com/tensorflow/linux/$CPU_GPU/tensorflow$GPUU-1.6.0-cp27-none-linux_x86_64.whl"
-
-echo ### ${INSTALL_PY3_PKGS} ###
-sudo python3 -m pip install jupyter
-sudo ln -sf /usr/local/bin/ipython /usr/bin/
-sudo ln -sf /usr/local/bin/jupyter /usr/bin/
-if [ "$INSTALL_PY3_PKGS" = true ]; then
-  sudo python3 -m pip install matplotlib seaborn bokeh cython networkx findspark
-  sudo python3 -m pip install pyhive sasl thrift thrift-sasl snakebite
-  # sudo python3 -m pip install google-cloud==0.32.0 mrjob || true # workaround the possible failure
-else
-  sudo python -m pip install matplotlib seaborn bokeh cython networkx findspark
-  sudo python -m pip install pyhive sasl thrift thrift-sasl snakebite --ignore-installed chardet
-  # sudo python -m pip install google-cloud==0.32.0 mrjob || true # workaround the possible failure
-fi
-
-echo ### ${DS_PACKAGES} ###
-if [ "$DS_PACKAGES" = true ]; then
-  # Python
-  if [ "$INSTALL_PY3_PKGS" = true ]; then
-    sudo python3 -m pip install scikit-learn pandas numpy numexpr statsmodels scipy
-  else
-    sudo python -m pip install scikit-learn pandas numpy numexpr statsmodels scipy    
-  fi
-  # Javascript
-  if [ "$JS_KERNEL" = true ]; then
-    sudo npm install -g --unsafe-perm stats-analysis decision-tree machine_learning limdu synaptic node-svm lda brain.js scikit-node
-  fi
-fi
-
-echo ### ${ML_PACKAGES} ###
-if [ "$ML_PACKAGES" = true ]; then
-  if [ "$INSTALL_PY3_PKGS" = true ]; then
-    sudo python3 -m pip install mxnet sagemaker
-    sudo python3 -m pip install $TF_BINARY_URL_PY3
-    sudo python3 -m pip install theano
-    sudo python3 -m pip install keras
-    sudo python3 -m pip install xgboost lightgbm opencv-python
-    #sudo python3 -m pip install pytorch # pytorch taking too long to setup, skip it for now
-  else
-    sudo python -m pip install mxnet sagemaker
-    sudo python -m pip install $TF_BINARY_URL
-    sudo python -m pip install theano
-    sudo python -m pip install keras
-    sudo python -m pip install xgboost lightgbm opencv-python
-    #sudo python3 -m pip install pytorch # pytorch taking too long to setup, skip it for now
-  fi
-fi
-
-echo ### ${PYTHON_PACKAGES} ###
-if [ ! "$PYTHON_PACKAGES" = "" ]; then
-  if [ "$INSTALL_PY3_PKGS" = true ]; then
-    sudo python3 -m pip install $PYTHON_PACKAGES || true
-  else
-    sudo python -m pip install $PYTHON_PACKAGES || true
-  fi
-fi
-
-echo ### ${BIGDL} ###
-if [ "$BIGDL" = true ]; then
-  aws s3 cp s3://tomzeng/maven/apache-maven-3.3.3-bin.tar.gz .
-  tar xvfz apache-maven-3.3.3-bin.tar.gz
-  sudo mv apache-maven-3.3.3 /opt/maven
-  sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
-
-  git clone https://github.com/intel-analytics/BigDL.git
-  cd BigDL/
-  export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
-  export BIGDL_HOME=/mnt/BigDL
-  export BIGDL_VER="0.6.0-SNAPSHOT"
-  bash make-dist.sh -P spark_2.x,scala_2.11
-  mkdir /tmp/bigdl_summaries
-  /usr/local/bin/tensorboard --debug INFO --logdir /tmp/bigdl_summaries/ > /tmp/tensorboard_bigdl.log 2>&1 &
-fi
-
-echo ### ${JULIA_KERNEL} ###
-
-if [ "$JULIA_KERNEL" = true ]; then
-  # Julia install
-  cd /mnt
-  if [ ! "$USE_CACHED_DEPS" = true ]; then
-    #wget https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-linux-x86_64.tar.gz # julia-3c9d75391c
-    #wget https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.1-linux-x86_64.tar.gz # julia-0d7248e2ff
-    #wget https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.2-linux-x86_64.tar.gz  # julia-d386e40c17
-    aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/julia-0.6.2-linux-x86_64.tar.gz .
-    #tar xvfz julia-0.5.0-linux-x86_64.tar.gz
-    #tar xvfz julia-0.6.1-linux-x86_64.tar.gz
-    tar xvfz julia-0.6.2-linux-x86_64.tar.gz
-  fi
-  #cd julia-3c9d75391c
-  #cd julia-0d7248e2ff
-  cd julia-d386e40c17
-  sudo cp -pr bin/* /usr/bin/
-  sudo cp -pr lib/* /usr/lib/
-  #sudo cp -pr libexec/* /usr/libexec/
-  sudo cp -pr share/* /usr/share/
-  sudo cp -pr include/* /usr/include/
-fi
-
-echo ### ${INSTALL_DASK} ###
-if [ "$INSTALL_DASK" = true ]; then
-  if [ "$INSTALL_PY3_PKGS" = true ]; then
-    sudo python3 -m pip install dask[complete] distributed
-  else
-    sudo python -m pip install dask[complete] distributed
-  fi
-  export PATH=$PATH:/usr/local/bin
-  if [ "$IS_MASTER" = true ]; then
-    dask-scheduler > /var/log/dask-scheduler.log 2>&1 &
-  else
-    MASTER_KV=$(grep masterHost /emr/instance-controller/lib/info/job-flow-state.txt)
-    MASTER_HOST=$(ruby -e "puts '$MASTER_KV'.gsub('\"','').split.last")
-    dask-worker $MASTER_HOST:8786 > /var/log/dask-worker.log 2>&1 &
-  fi
-fi
-
-#echo ". /mnt/ipython-env/bin/activate" >> ~/.bashrc
-
-# only run below on master instance
-if [ "$IS_MASTER" = true ]; then
-echo ### ${RUBY_KERNEL} ###
-if [ "$RUBY_KERNEL" = true ]; then
-  cd /mnt
-  if [ "$USE_CACHED_DEPS" != true ]; then
-    #wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz
-    wget https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz
-    #tar xvzf ruby-2.1.8.tar.gz
-    tar xvzf ruby-2.5.0.tar.gz
-  fi
-  #cd ruby-2.1.8
-  cd ruby-2.5.0
-  ./configure --prefix=/usr
-  make -j $NPROC
-  sudo make install
-  #sudo gem install puppet -v=3.7.4 -N
-  sudo gem install rbczmq iruby -N
-  sudo gem install presto-client -N
-  sudo iruby register
-  sudo cp -pr /root/.ipython/kernels/ruby /usr/local/share/jupyter/kernels/
-  iruby register
-fi
-
-sudo mkdir -p /var/log/jupyter
-mkdir -p ~/.jupyter
-touch ~/.jupyter/jupyter_notebook_config.py
-
-sed -i '/c.NotebookApp.open_browser/d' ~/.jupyter/jupyter_notebook_config.py
-echo "c.NotebookApp.open_browser = False" >> ~/.jupyter/jupyter_notebook_config.py
-
-if [ ! "$JUPYTER_LOCALHOST_ONLY" = true ]; then
-sed -i '/c.NotebookApp.ip/d' ~/.jupyter/jupyter_notebook_config.py
-echo "c.NotebookApp.ip='*'" >> ~/.jupyter/jupyter_notebook_config.py
-fi
-
-sed -i '/c.NotebookApp.port/d' ~/.jupyter/jupyter_notebook_config.py
-echo "c.NotebookApp.port = $JUPYTER_PORT" >> ~/.jupyter/jupyter_notebook_config.py
-
-echo ### ${JUPYTER_PASSWORD} ###
-if [ ! "$JUPYTER_PASSWORD" = "" ]; then
-  sed -i '/c.NotebookApp.password/d' ~/.jupyter/jupyter_notebook_config.py
-  HASHED_PASSWORD=$(python3 -c "from notebook.auth import passwd; print(passwd('$JUPYTER_PASSWORD'))")
-  echo "c.NotebookApp.password = u'$HASHED_PASSWORD'" >> ~/.jupyter/jupyter_notebook_config.py
-else
-  sed -i '/c.NotebookApp.token/d' ~/.jupyter/jupyter_notebook_config.py
-  echo "c.NotebookApp.token = u''" >> ~/.jupyter/jupyter_notebook_config.py
-fi
-
-echo "c.Authenticator.admin_users = {'$JUPYTER_HUB_DEFAULT_USER'}" >> ~/.jupyter/jupyter_notebook_config.py
-echo "c.LocalAuthenticator.create_system_users = True" >> ~/.jupyter/jupyter_notebook_config.py
-
-echo ### ${SSL} ###
-
-if [ "$SSL" = true ]; then
-  #NOTE - replace server.cert and server.key with your own cert and key files
-  CERT=/usr/local/etc/server.cert
-  KEY=/usr/local/etc/server.key
-  sudo openssl req -x509 -nodes -days 3650 -newkey rsa:1024 -keyout $KEY -out $CERT -subj "/C=US/ST=Washington/L=Seattle/O=JupyterCert/CN=JupyterCert"
-  
-  # the following works for Jupyter but will fail JupyterHub, use options for both instead
-  #echo "c.NotebookApp.certfile = u'/usr/local/etc/server.cert'" >> ~/.jupyter/jupyter_notebook_config.py
-  #echo "c.NotebookApp.keyfile = u'/usr/local/etc/server.key'" >> ~/.jupyter/jupyter_notebook_config.py
-
-  SSL_OPTS_JUPYTER="--keyfile=/usr/local/etc/server.key --certfile=/usr/local/etc/server.cert"
-  SSL_OPTS_JUPYTERHUB="--ssl-key=/usr/local/etc/server.key --ssl-cert=/usr/local/etc/server.cert"
-fi
-
-# install default kernels
-sudo python3 -m pip install $UPDATE_FLAG notebook ipykernel
-sudo python3 -m pip install tornado==4.5.3 # fix the latest tonardo and asyncio package conflict
-sudo python3 -m ipykernel install
-sudo python -m pip install $UPDATE_FLAG notebook ipykernel
-sudo python -m ipykernel install
-sudo python3 -m pip install metakernel
-#sudo python3 -m pip install gnuplot_kernel
-#sudo python3 -m gnuplot_kernel install
-sudo python3 -m pip install bash_kernel
-sudo python3 -m bash_kernel.install
-
-echo ### ${JS_KERNEL} ###
-
-# Javascript/CoffeeScript kernels
-if [ "$JS_KERNEL" = true ]; then
-  sudo npm install -g --unsafe-perm ijavascript d3 lodash plotly jp-coffeescript
-  sudo ijs --ijs-install=global
-  sudo jp-coffee --jp-install=global
-fi
-sudo python3 -m pip install $UPDATE_FLAG jupyter_contrib_nbextensions
-sudo python -m pip install $UPDATE_FLAG jupyter_contrib_nbextensions
-sudo python3 -m pip install -U six
-sudo python -m pip install -U six
-sudo jupyter contrib nbextension install --system
-sudo python3 -m pip install $UPDATE_FLAG jupyter_nbextensions_configurator
-sudo python -m pip install $UPDATE_FLAG jupyter_nbextensions_configurator
-sudo jupyter nbextensions_configurator enable --system
-sudo python3 -m pip install $UPDATE_FLAG ipywidgets
-sudo python -m pip install $UPDATE_FLAG ipywidgets
-sudo jupyter nbextension enable --py --sys-prefix widgetsnbextension
-
-sudo python3 -m pip install pyeda # only work for python3
-sudo python -m pip install gvmagic py_d3
-sudo python -m pip install ipython-sql
-
-echo ### ${JULIA_KERNEL} ###
-
-if [ "$JULIA_KERNEL" = true ]; then
-  julia -e 'Pkg.add("IJulia")'
-  julia -e 'Pkg.add("RDatasets");Pkg.add("Gadfly");Pkg.add("DataFrames");Pkg.add("PyPlot")'
-  # Julia's Spark support does not support Spark on Yarn yet
-  # install mvn
-  #cd /mnt
-  #aws s3 cp s3://tomzeng/maven/apache-maven-3.3.9-bin.tar.gz .
-  #tar xvfz apache-maven-3.3.9-bin.tar.gz
-  #sudo mv apache-maven-3.3.9 /opt/maven
-  #sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
-  # install Spark for Julia
-  #julia -e 'Pkg.clone("https://github.com/dfdx/Spark.jl"); Pkg.build("Spark"); Pkg.checkout("JavaCall")'
-fi
-
-echo ### ${TORCH_KERNEL} ###
-
-# iTorch depends on Torch which is installed with --ml-packages
-if [ "$TORCH_KERNEL" = true ]; then
-  set +e # workaround for the lengthy torch install-deps, esp when other background process are also running yum
-  cd /mnt
-  if [ ! "$USE_CACHED_DEPS" = true ]; then
-    git clone https://github.com/torch/distro.git torch-distro
-  fi
-  cd torch-distro
-  git pull
-  ./install-deps
-  ./install.sh -b
-  export PATH=$PATH:/mnt/torch-distro/install/bin
-  source ~/.profile
-  luarocks install lzmq
-  luarocks install gnuplot
-  cd /mnt
-  if [ ! "$USE_CACHED_DEPS" = true ]; then
-    git clone https://github.com/facebook/iTorch.git
-  fi
-  cd iTorch
-  luarocks make
-  #sudo env "PATH=$PATH:/usr/local/bin" luarocks make install
-  #sudo chown -R $USER $(dirname $(ipython locate profile))
-  sudo cp -pr ~/.ipython/kernels/itorch /usr/local/share/jupyter/kernels/
-  set -e
-fi
-
-echo ### ${R_KERNEL} n ${TOREE_KERNEL} ###
-
-if [ "$R_KERNEL" = true ] || [ "$TOREE_KERNEL" = true ]; 
-then
-  sudo yum install -y R-devel readline-dev
-  sudo ln -s /usr/lib/gcc/x86_64-amazon-linux/6.4.1/libgomp.spec /usr/lib64/libgomp.spec
-  sudo ln -s /usr/lib/gcc/x86_64-amazon-linux/6.4.1/libgomp.a /usr/lib64/libgomp.a
-  sudo ln -s /usr/lib64/libgomp.so.1.0.0 /usr/lib64/libgomp.so
-  aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/rpy2-2.8.6.tar.gz /mnt/
-  sudo python -m pip install -Iv /mnt/rpy2-2.8.6.tar.gz
-
-  if [ ! -f /tmp/Renvextra ]; then # check if the rstudio ba was run, it does this already 
-   sudo sed -i "s/make/make -j $NPROC/g" /usr/lib64/R/etc/Renviron
-  fi
-
-  sudo R --no-save << R_SCRIPT
-    #install.packages(c('devtools', 'RJSONIO', 'itertools', 'digest', 'Rcpp', 'functional', 'httr', 'plyr', 'stringr', 'reshape2', 'caTools', 'rJava', 'DBI', 'ggplot2', 'dplyr', 'R.methodsS3', 'Hmisc', 'memoise', 'rjson'), repos="$R_REPOS", quiet = FALSE)
-    install.packages(c('devtools'), repos="$R_REPOS", quiet = FALSE)
-    # For the Granger Causuality example deps
-    library(devtools)
-    #install.packages(c('fUnitRoots','vars','aod','tseries'), repos="$R_REPOS", quiet = FALSE)
-R_SCRIPT
-fi
-
-# IRKernal setup 
-if [ "$R_KERNEL" = true ]; then
-  sudo R --no-save << R_SCRIPT
-    install.packages(c("devtools","XML","readr","httr","RCurl","data.table","parallel","tidyverse","dplyr","knitr","gplots","tidyr","shiny","ggplot2","rlist","ggthemes","lubridate","Rcpp","reshape", "RJSONIO", "itertools", "digest", "functional", "httr", "plyr", "stringr", "reshape2", "caTools", "rJava", "DBI", "R.methodsS3", "Hmisc", "memoise", "rjson", "IRdisplay", "evaluate", "crayon", "pbdZMQ", "uuid", "digest", "e1071", "party"), repos="$R_REPOS", quiet = TRUE)
-    devtools::install_github("IRkernel/IRkernel")
-    IRkernel::installspec(user = FALSE)
-R_SCRIPT
-fi
-
-echo ### ${NOTEBOOK_DIR} ###
-
-if [ ! "$NOTEBOOK_DIR" = "" ]; then
-  NOTEBOOK_DIR="${NOTEBOOK_DIR%/}/" # remove trailing / if exists then add /
-  if [[ "$NOTEBOOK_DIR" == s3://* ]]; then
-    NOTEBOOK_DIR_S3=true
-    # the s3nb does not fully working yet(upload and createe folder not working)
-    # s3nb does not work anymore due to Jupyter update
-    if [ "$NOTEBOOK_DIR_S3_S3NB" = true ]; then
-      cd /mnt
-      if [ ! "$USE_CACHED_DEPS" = true ]; then
-        git clone https://github.com/tomz/s3nb.git
-      fi
-      cd s3nb
-      sudo python -m pip install entrypoints
-      sudo python setup.py install
-      if [ "$JUPYTER_HUB" = true ]; then
-        sudo python3 -m pip install entrypoints
-        sudo python3 setup.py install
-      fi
-
-      echo "c.NotebookApp.contents_manager_class = 's3nb.S3ContentsManager'" >> ~/.jupyter/jupyter_notebook_config.py
-      echo "c.S3ContentsManager.checkpoints_kwargs = {'root_dir': '~/.checkpoints'}" >> ~/.jupyter/jupyter_notebook_config.py
-      # if just bucket with no subfolder, a trailing / is required, otherwise s3nb will break
-      echo "c.S3ContentsManager.s3_base_uri = '$NOTEBOOK_DIR'" >> ~/.jupyter/jupyter_notebook_config.py
-      #echo "c.S3ContentsManager.s3_base_uri = '${NOTEBOOK_DIR_S3%/}/%U'" >> ~/.jupyter/jupyter_notebook_config.py
-      #echo "c.Spawner.default_url = '${NOTEBOOK_DIR_S3%/}/%U'" >> ~/.jupyter/jupyter_notebook_config.py
-      #echo "c.Spawner.notebook_dir = '/%U'" >> ~/.jupyter/jupyter_notebook_config.py 
-    elif [ "$NOTEBOOK_DIR_S3_S3CONTENTS" = true ]; then
-      BUCKET=$(ruby -e "puts '$NOTEBOOK_DIR'.split('//')[1].split('/')[0]")
-      FOLDER=$(ruby -e "puts '$NOTEBOOK_DIR'.split('//')[1].split('/')[1..-1].join('/')")
-      #sudo python -m pip install s3contents
-      cd /mnt
-      #aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/s3contents.zip .
-      #unzip s3contents.zip
-      git clone https://github.com/tomz/s3contents.git
-      cd s3contents
-      sudo python setup.py install
-      echo "c.NotebookApp.contents_manager_class = 's3contents.S3ContentsManager'" >> ~/.jupyter/jupyter_notebook_config.py
-      echo "c.S3ContentsManager.bucket_name = '$BUCKET'" >> ~/.jupyter/jupyter_notebook_config.py
-      echo "c.S3ContentsManager.prefix = '$FOLDER'" >> ~/.jupyter/jupyter_notebook_config.py
-      # this following is no longer needed, default was fixed in the latest on github
-      #echo "c.S3ContentsManager.endpoint_url = 'https://s3.amazonaws.com'" >> ~/.jupyter/jupyter_notebook_config.py
-    else
-      BUCKET=$(ruby -e "puts '$NOTEBOOK_DIR'.split('//')[1].split('/')[0]")
-      FOLDER=$(ruby -e "puts '$NOTEBOOK_DIR'.split('//')[1].split('/')[1..-1].join('/')")
-      if [ "$USE_CACHED_DEPS" != true ]; then
-        sudo yum install -y automake fuse fuse-devel libxml2-devel
-      fi
-      cd /mnt
-      git clone https://github.com/s3fs-fuse/s3fs-fuse.git
-      cd s3fs-fuse/
-      ls -alrt
-      ./autogen.sh
-      ./configure
-      make -j $NPROC
-      sudo make install
-      sudo su -c 'echo user_allow_other >> /etc/fuse.conf'
-      mkdir -p /mnt/s3fs-cache
-      mkdir -p /mnt/$BUCKET
-      #/usr/local/bin/s3fs -o allow_other -o iam_role=auto -o umask=0 $BUCKET /mnt/$BUCKET
-      # -o nodnscache -o nosscache -o parallel_count=20  -o multipart_size=50
-      S3SSE_FLAG=""
-      if [ "$USE_SSE" = true ]; then
-        if [ ! "KMS_ID" = "" ]; then
-          S3SSE_FLAG = "-o use_sse='kmsid:$KMS_ID'"
-        else
-          S3SSE_FLAG = "-o use_sse"
-        fi
-      fi
-      /usr/local/bin/s3fs -o allow_other -o iam_role=auto -o umask=0 -o url=https://s3.amazonaws.com  -o no_check_certificate -o enable_noobj_cache -o use_cache=/mnt/s3fs-cache $S3SSE_FLAG $BUCKET /mnt/$BUCKET
-      if [ "$JUPYTER_HUB" = true ]; then
-        mkdir -p /mnt/$BUCKET/$FOLDER/${JUPYTER_HUB_DEFAULT_USER}
-      fi
-      #/usr/local/bin/s3fs -o allow_other -o iam_role=auto -o umask=0 -o use_cache=/mnt/s3fs-cache $BUCKET /mnt/$BUCKET
-      echo "c.NotebookApp.notebook_dir = '/mnt/$BUCKET/$FOLDER'" >> ~/.jupyter/jupyter_notebook_config.py
-      echo "c.ContentsManager.checkpoints_kwargs = {'root_dir': '.checkpoints'}" >> ~/.jupyter/jupyter_notebook_config.py
-      if [ "$JUPYTER_HUB" = true ]; then
-        echo "try:" >> ~/.jupyter/jupyter_notebook_config.py
-        echo "  from jupyterhub.spawner import LocalProcessSpawner" >> ~/.jupyter/jupyter_notebook_config.py
-        echo "  class MySpawner(LocalProcessSpawner):" >> ~/.jupyter/jupyter_notebook_config.py
-        echo "      def _notebook_dir_default(self):" >> ~/.jupyter/jupyter_notebook_config.py
-        echo "        return c.NotebookApp.notebook_dir + '/' + self.user.name" >> ~/.jupyter/jupyter_notebook_config.py
-        echo "  c.JupyterHub.spawner_class = MySpawner" >> ~/.jupyter/jupyter_notebook_config.py 
-        echo "except:" >> ~/.jupyter/jupyter_notebook_config.py
-        echo "  print('jupyterhub module not found')" >> ~/.jupyter/jupyter_notebook_config.py
-      fi
-    fi
-  else
-    echo "c.NotebookApp.notebook_dir = '$NOTEBOOK_DIR'" >> ~/.jupyter/jupyter_notebook_config.py
-    echo "c.ContentsManager.checkpoints_kwargs = {'root_dir': '.checkpoints'}" >> ~/.jupyter/jupyter_notebook_config.py
-  fi
-fi
-
-echo '### ${JUPYTER_HUB_DEFAULT_USER} ###'
-
-if [ ! "$JUPYTER_HUB_DEFAULT_USER" = "" ]; then
-  sudo adduser $JUPYTER_HUB_DEFAULT_USER
-fi
-
-echo ### ${COPY_SAMPLES} ###
-if [ "$COPY_SAMPLES" = true ]; then
-  cd ~
-  if [ "$NOTEBOOK_DIR_S3" = true ]; then
-    aws s3 sync s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/notebooks/ ${NOTEBOOK_DIR}samples/ || true
-    if [ "$JUPYTER_HUB" = true ]; then
-      aws s3 sync s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/notebooks/ ${NOTEBOOK_DIR}${JUPYTER_HUB_DEFAULT_USER}/samples/ || true
-    fi
-  else
-    if [ ! "$NOTEBOOK_DIR" = "" ]; then
-      mkdir -p ${NOTEBOOK_DIR}samples || true
-      sudo mkdir /home/$JUPYTER_HUB_DEFAULT_USER/${NOTEBOOK_DIR}samples || true
-    fi
-    aws s3 sync s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/notebooks/ ${NOTEBOOK_DIR}samples || true
-    sudo cp -pr ${NOTEBOOK_DIR}samples /home/$JUPYTER_HUB_DEFAULT_USER/
-    sudo chown -R $JUPYTER_HUB_DEFAULT_USER:$JUPYTER_HUB_DEFAULT_USER /home/$JUPYTER_HUB_DEFAULT_USER/${NOTEBOOK_DIR}samples
-  fi
-fi
-
-
-wait_for_spark() {
-  while [ ! -f /var/run/spark/spark-history-server.pid ]
-  do
-    sleep 10
-  done
-}
-
-setup_jupyter_process_with_bigdl() {
-  wait_for_spark
-  export PYTHON_API_PATH=${BIGDL_HOME}/dist/lib/bigdl-$BIGDL_VER-python-api.zip
-  export BIGDL_JAR_PATH=${BIGDL_HOME}/dist/lib/bigdl-$BIGDL_VER-jar-with-dependencies.jar
-  cat ${BIGDL_HOME}/dist/conf/spark-bigdl.conf | sudo tee -a /etc/spark/conf/spark-defaults.conf
-#   sudo puppet apply << PUPPET_SCRIPT
-#   include 'upstart'
-#   upstart::job { 'jupyter':
-#     description    => 'Jupyter',
-#     respawn        => true,
-#     respawn_limit  => '0 10',
-#     start_on       => 'runlevel [2345]',
-#     stop_on        => 'runlevel [016]',
-#     console        => 'output',
-#     chdir          => '/home/hadoop',
-#     script           => '
-#     sudo su - hadoop > /var/log/jupyter/jupyter.log 2>&1 <<BASH_SCRIPT
-#     export NODE_PATH="$NODE_PATH"
-#     export PYSPARK_DRIVER_PYTHON="jupyter"
-#     export PYSPARK_DRIVER_PYTHON_OPTS="notebook --no-browser $SSL_OPTS_JUPYTER --log-level=INFO"
-#     export NOTEBOOK_DIR="$NOTEBOOK_DIR"
-
-#     export BIGDL_HOME=/mnt/BigDL
-#     export SPARK_HOME=/usr/lib/spark
-#     export YARN_CONF_DIR=/etc/hadoop/conf
-#     export PYTHONPATH=${PYTHON_API_PATH}:$PYTHONPATH
-#     source ${BIGDL_HOME}/dist/bin/bigdl.sh
-#     #pyspark --py-files ${PYTHON_API_PATH} --jars ${BIGDL_JAR_PATH} --conf spark.driver.extraClassPath=${BIGDL_JAR_PATH} --conf spark.executor.extraClassPath=bigdl-${BIGDL_VER}-jar-with-dependencies.jar
-#     pyspark --py-files ${PYTHON_API_PATH} --jars ${BIGDL_JAR_PATH}
-# BASH_SCRIPT
-#     ',
-#   }
-# PUPPET_SCRIPT
-}
-
-background_install_proc() {
-  wait_for_spark
-  
-  if ! grep "spark.sql.catalogImplementation" /etc/spark/conf/spark-defaults.conf; then
-    sudo bash -c "echo 'spark.sql.catalogImplementation  hive' >> /etc/spark/conf/spark-defaults.conf"
-  fi
-  
-  if [ ! -f /tmp/Renvextra ]; then # check if the rstudio BA maybe already done this
-    cat << 'EOF' > /tmp/Renvextra
-JAVA_HOME="/etc/alternatives/jre"
-HADOOP_HOME_WARN_SUPPRESS="true"
-HADOOP_HOME="/usr/lib/hadoop"
-HADOOP_PREFIX="/usr/lib/hadoop"
-HADOOP_MAPRED_HOME="/usr/lib/hadoop-mapreduce"
-HADOOP_YARN_HOME="/usr/lib/hadoop-yarn"
-HADOOP_COMMON_HOME="/usr/lib/hadoop"
-HADOOP_HDFS_HOME="/usr/lib/hadoop-hdfs"
-HADOOP_CONF_DIR="/usr/lib/hadoop/etc/hadoop"
-YARN_CONF_DIR="/usr/lib/hadoop/etc/hadoop"
-YARN_HOME="/usr/lib/hadoop-yarn"
-HIVE_HOME="/usr/lib/hive"
-HIVE_CONF_DIR="/usr/lib/hive/conf"
-HBASE_HOME="/usr/lib/hbase"
-HBASE_CONF_DIR="/usr/lib/hbase/conf"
-SPARK_HOME="/usr/lib/spark"
-SPARK_CONF_DIR="/usr/lib/spark/conf"
-PATH=${PWD}:${PATH}
-EOF
-
-  #if [ "$PYSPARK_PYTHON" = "python3" ]; then
-  if [ "$INSTALL_PY3_PKGS" = true ]; then
-    cat << 'EOF' >> /tmp/Renvextra
-PYSPARK_PYTHON="python3"
-EOF
-  fi
-
-  cat /tmp/Renvextra | sudo tee -a /usr/lib64/R/etc/Renviron
-
-  sudo mkdir -p /mnt/spark
-  sudo chmod a+rwx /mnt/spark
-  if [ -d /mnt1 ]; then
-    sudo mkdir -p /mnt1/spark
-    sudo chmod a+rwx /mnt1/spark
-  fi
-
-  sudo R --no-save << R_SCRIPT
-  library(devtools)
-  devtools::install_github("rstudio/sparklyr")
-  install.packages(c('nycflights13', 'Lahman', 'data.table'), repos="$R_REPOS", quiet = TRUE)
-R_SCRIPT
-
-  set +e # workaround for if SparkR is already installed by other BA
-  # install SparkR and SparklyR for R - toree ifself does not need this
-  sudo R --no-save << R_SCRIPT
-  library(devtools)
-  install('/usr/lib/spark/R/lib/SparkR')
-R_SCRIPT
-  set -e
-
-  fi # end if -f /tmp/Renvextra
-
-  sudo python3 -m pip install /mnt/incubator-toree/dist/toree-pip
-
-  #sudo ln -sf /usr/local/bin/jupyter-toree /usr/bin/
-  export SPARK_HOME="/usr/lib/spark"
-  SPARK_PACKAGES=""
-
-  PYSPARK_PYTHON="python3"
-  
-  if [ ! "$USER_SPARK_OPTS" = "" ]; then
-    SPARK_OPTS=$USER_SPARK_OPTS
-    SPARK_PACKAGES=$(ruby -e "opts='$SPARK_OPTS'.split;pkgs=nil;opts.each_with_index{|o,i| pkgs=opts[i+1] if o.start_with?('--packages')};puts pkgs || '$SPARK_PACKAGES'")
-    export SPARK_OPTS
-    export SPARK_PACKAGES
-    
-    sudo jupyter toree install --interpreters=$INTERPRETERS --spark_home=$SPARK_HOME --python_exec=$PYSPARK_PYTHON --spark_opts="$SPARK_OPTS"
-    # NOTE - toree does not pick SPARK_OPTS, so use the following workaround until it's fixed  
-    if [ ! "$SPARK_PACKAGES" = "" ]; then
-      if ! grep "spark.jars.packages" /etc/spark/conf/spark-defaults.conf; then
-        sudo bash -c "echo 'spark.jars.packages              $SPARK_PACKAGES' >> /etc/spark/conf/spark-defaults.conf"
-      fi
-    fi
-  else
-    sudo jupyter toree install --interpreters=$INTERPRETERS --spark_home=$SPARK_HOME --python_exec=$PYSPARK_PYTHON
-  fi
-
-  
-  if [ "$INSTALL_PY3_PKGS" = true ]; then
-    sudo bash -c 'echo "" >> /etc/spark/conf/spark-env.sh'
-    sudo bash -c 'echo "export PYSPARK_PYTHON=/usr/bin/python3" >> /etc/spark/conf/spark-env.sh'
-    
-    #if [ -f /usr/local/share/jupyter/kernels/apache_toree_pyspark/kernel.json ]; then
-    #  sudo bash -c 'sed -i "s/\"PYTHON_EXEC\": \"python\"/\"PYTHON_EXEC\": \"\/usr\/bin\/python3\"/g" /usr/local/share/jupyter/kernels/apache_toree_pyspark/kernel.json'
-    #fi
-    
-  fi
-  
-  # the following dirs could cause conflict, so remove them
-  rm -rf ~/.m2/
-  rm -rf ~/.ivy2/
-  
-  if [ "$NO_JUPYTER" = false ]; then
-    echo "Starting Jupyter notebook via pyspark"
-    cd ~
-    #PYSPARK_DRIVER_PYTHON=jupyter PYSPARK_DRIVER_PYTHON_OPTS="notebook --no-browser" pyspark > /var/log/jupyter/jupyter.log &
-#    if [ "$BIGDL" = false ]; then
-#       sudo puppet apply << PUPPET_SCRIPT
-#       include 'upstart'
-#       upstart::job { 'jupyter':
-#         description    => 'Jupyter',
-#         respawn        => true,
-#         respawn_limit  => '0 10',
-#         start_on       => 'runlevel [2345]',
-#         stop_on        => 'runlevel [016]',
-#         console        => 'output',
-#         chdir          => '/home/hadoop',
-#         script           => '
-#         sudo su - hadoop > /var/log/jupyter/jupyter.log 2>&1 <<BASH_SCRIPT
-#         export NODE_PATH="$NODE_PATH"
-#         export PYSPARK_DRIVER_PYTHON="jupyter"
-#         export PYSPARK_DRIVER_PYTHON_OPTS="notebook --no-browser $SSL_OPTS_JUPYTER --log-level=INFO"
-#         export NOTEBOOK_DIR="$NOTEBOOK_DIR"
-#         pyspark
-# BASH_SCRIPT
-#         ',
-#       }
-# PUPPET_SCRIPT
-    # else
-    #   setup_jupyter_process_with_bigdl
-    # fi
-  fi
-}
-
-create_hdfs_user() {
-  wait_for_spark
-  sudo -u hdfs hdfs dfs -mkdir /user/$JUPYTER_HUB_DEFAULT_USER
-  sudo -u hdfs hdfs dfs -chown $JUPYTER_HUB_DEFAULT_USER:$JUPYTER_HUB_DEFAULT_USER /user/$JUPYTER_HUB_DEFAULT_USER
-  sudo -u hdfs hdfs dfs -chmod -R 777 /user/$JUPYTER_HUB_DEFAULT_USER
-}
-
-# apache toree install
-if [ "$TOREE_KERNEL" = true ]; then
-  echo "Running background process to install Apacke Toree"
-  # spark 1.6
-  #sudo pip install --pre toree
-  #sudo jupyter toree install
-
-  # spark 2.0
-  cd /mnt
-  if [ "$USE_CACHED_DEPS" != true ]; then
-    #curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm.repo
-    #sudo yum install sbt -y
-    #binstry sbt rpm repo goes down sometimes, switch to manuall install:    
-    aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/sbt-1.1.1.tgz .
-    tar xvfz sbt-1.1.1.tgz
-    sudo mv sbt/bin/* /usr/bin/
-    sudo mv sbt/conf /etc/sbt
-    rm -rf sbt
-    
-    sudo yum install docker -y
-  fi
-  if [ ! "$USE_CACHED_DEPS" = true ]; then
-    git clone https://github.com/apache/incubator-toree.git
-  fi
-  cd incubator-toree/
-  git pull
-  export APACHE_SPARK_VERSION=$APACHE_SPARK_VERSION
-  make -j $NPROC dist
-  sed -i "s/docker run -t/sudo docker run -t/" Makefile
-  make clean release APACHE_SPARK_VERSION=$APACHE_SPARK_VERSION || true # gettting the docker not running error, swallow it with || true
-  if [ "$RUN_AS_STEP" = true ]; then
-    background_install_proc
-  else
-    background_install_proc &
-  fi
-else
-  if [ "$NO_JUPYTER" = false ]; then
-    echo "Starting Jupyter notebook"
-    # if [ "$BIGDL" = false ]; then
-#       sudo puppet apply << PUPPET_SCRIPT
-#       include 'upstart'
-#       upstart::job { 'jupyter':
-#           description    => 'Jupyter'
-#           respawn        => true,
-#           respawn_limit  => '0 10',
-#           start_on       => 'runlevel [2345]',
-#           stop_on        => 'runlevel [016]',
-#           console        => 'output',
-#           chdir          => '/home/hadoop',
-#           env            => { 'NOTEBOOK_DIR' => '$NOTEBOOK_DIR', 'NODE_PATH' => '$NODE_PATH' },
-#           exec           => 'sudo su - hadoop -c "jupyter notebook --no-browser $SSL_OPTS_JUPYTER" > /var/log/jupyter/jupyter.log 2>&1',
-#       }
-# PUPPET_SCRIPT
-    # else
-    #   setup_jupyter_process_with_bigdl &
-    # fi
-  fi
-fi
-
-echo '### ${JUPYTER_HUB} ###'
-if [ "$JUPYTER_HUB" = true ]; then
-  sudo npm install -g --unsafe-perm configurable-http-proxy
-  sudo python3 -m pip install $UPDATE_FLAG jupyterhub #notebook ipykernel
-  #sudo python3 -m ipykernel install
-  
-  if [ ! "$JUPYTER_HUB_DEFAULT_USER" = "" ]; then
-    create_hdfs_user &
-  fi
-  # change the password of the hadoop user to JUPYTER_PASSWORD
-  if [ ! "$JUPYTER_PASSWORD" = "" ]; then
-    sudo sh -c "echo '$JUPYTER_PASSWORD' | passwd --stdin $JUPYTER_HUB_DEFAULT_USER"
-  fi
-  
-  sudo ln -sf /usr/local/bin/jupyterhub /usr/bin/
-  sudo ln -sf /usr/local/bin/jupyterhub-singleuser /usr/bin/
-  mkdir -p /mnt/jupyterhub
-  cd /mnt/jupyterhub
-  echo "Starting Jupyterhub"
-  #sudo jupyterhub $SSL_OPTS_JUPYTERHUB --port=$JUPYTER_HUB_PORT --ip=$JUPYTER_HUB_IP --log-file=/var/log/jupyter/jupyterhub.log --config ~/.jupyter/jupyter_notebook_config.py &
-#   sudo puppet apply << PUPPET_SCRIPT
-#   include 'upstart'
-#   upstart::job { 'jupyterhub':
-#       description    => 'JupyterHub',
-#       respawn        => true,
-#       respawn_limit  => '0 10',
-#       start_on       => 'runlevel [2345]',
-#       stop_on        => 'runlevel [016]',
-#       console        => 'output',
-#       chdir          => '/mnt/jupyterhub',
-#       env            => { 'NOTEBOOK_DIR' => '$NOTEBOOK_DIR', 'NODE_PATH' => '$NODE_PATH' },
-#       exec           => 'sudo /usr/bin/jupyterhub --pid-file=/var/run/jupyter.pid $SSL_OPTS_JUPYTERHUB --port=$JUPYTER_HUB_PORT --ip=$JUPYTER_HUB_IP --log-file=/var/log/jupyter/jupyterhub.log --config /home/hadoop/.jupyter/jupyter_notebook_config.py'
-#   }
-# PUPPET_SCRIPT
-
-fi
-
-# cat << 'EOF' > /tmp/jupyter_logpusher.config
+# # error message
+# error_msg ()
 # {
-#   "/var/log/jupyter/" : {
-#     "includes" : [ "(.*)" ],
-#     "s3Path" : "node/$instance-id/applications/jupyter/$0",
-#     "retentionPeriod" : "5d",
-#     "logType" : [ "USER_LOG", "SYSTEM_LOG" ]
-#   }
+#   echo 1>&2 "Error: $1"
 # }
-# EOF
-# cat /tmp/jupyter_logpusher.config | sudo tee -a /etc/logpusher/jupyter.config
 
-fi
-echo "Bootstrap action finished"
+# # some defaults
+# RUBY_KERNEL=false
+# R_KERNEL=true
+# JULIA_KERNEL=false
+# TOREE_KERNEL=true
+# TORCH_KERNEL=false
+# DS_PACKAGES=false
+# ML_PACKAGES=false
+# PYTHON_PACKAGES="pyserial oauth cheetah argparse PrettyTable wheel pandas parsimonious tornado jupyter numpy collections math pprint bokeh scikit-learn matplotlib ggplot"
+# RUN_AS_STEP=false
+# NOTEBOOK_DIR=""
+# NOTEBOOK_DIR_S3=false
+# JUPYTER_PORT=8192
+# JUPYTER_PASSWORD=""
+# JUPYTER_LOCALHOST_ONLY=false
+# PYTHON3=true
+# GPU=false
+# CPU_GPU="cpu"
+# GPUU=""
+# JUPYTER_HUB=false
+# JUPYTER_HUB_PORT=8007
+# JUPYTER_HUB_IP="*"
+# JUPYTER_HUB_DEFAULT_USER="jupyter"
+# INTERPRETERS="Scala,SQL,PySpark,SparkR"
+# R_REPOS_LOCAL="file:////mnt/miniCRAN"
+# R_REPOS_REMOTE="https://cran.r-project.org"
+# USE_CACHED_DEPS=false
+# R_REPOS=$R_REPOS_REMOTE
+# SSL=false
+# SSL_OPTS="--no-ssl"
+# COPY_SAMPES=false
+# USER_SPARK_OPTS=""
+# NOTEBOOK_DIR_S3_S3NB=false
+# NOTEBOOK_DIR_S3_S3CONTENTS=true
+# JS_KERNEL=false
+# NO_JUPYTER=false
+# INSTALL_DASK=false
+# INSTALL_PY3_PKGS=true
+# APACHE_SPARK_VERSION="2.4.2"
+# BIGDL=false
+# MXNET=false
+# DL4J=false
+# NPROC=$(nproc)
+# UPDATE_FLAG=""
+# USE_SSE=false
+# KMS_ID=""
+
+# # get input parameters
+# while [ $# -gt 0 ]; do
+#     case "$1" in
+#     --r)
+#       R_KERNEL=true
+#       ;;
+#     --julia)
+#       JULIA_KERNEL=true
+#       ;;
+#     --toree)
+#       TOREE_KERNEL=true
+#       ;;
+#     --torch)
+#       TORCH_KERNEL=true
+#       ;;
+#     --javascript)
+#       JS_KERNEL=true
+#       ;;
+#     --ds-packages)
+#       DS_PACKAGES=true
+#       ;;
+#     --ml-packages)
+#       ML_PACKAGES=true
+#       ;;
+#     --python-packages)
+#       shift
+#       PYTHON_PACKAGES=$1
+#       ;;
+#     --bigdl)
+#       BIGDL=true
+#       ;;
+#     --mxnet)
+#       MXNET=true
+#       ;;
+#     --dl4j)
+#       DL4J=true
+#       ;;
+#     --ruby)
+#       RUBY_KERNEL=true
+#       ;;
+#     --gpu)
+#       GPU=true
+#       CPU_GPU="gpu"
+#       GPUU="_gpu"
+#       ;;
+#     --run-as-step)
+#       RUN_AS_STEP=true
+#       ;;
+#     --port)
+#       shift
+#       JUPYTER_PORT=$1
+#       ;;
+#     --user)
+#       shift
+#       JUPYTER_HUB_DEFAULT_USER=$1
+#       ;;
+#     --password)
+#       shift
+#       JUPYTER_PASSWORD=$1
+#       ;;
+#     --localhost-only)
+#       JUPYTER_LOCALHOST_ONLY=true
+#       JUPYTER_HUB_IP=""
+#       ;;
+#     --jupyterhub)
+#       JUPYTER_HUB=true
+#       #PYTHON3=true
+#       ;;
+#     --jupyterhub-port)
+#       shift
+#       JUPYTER_HUB_PORT=$1
+#       ;;
+#     --notebook-dir)
+#       shift
+#       NOTEBOOK_DIR=$1
+#       ;;
+#     --copy-samples)
+#       COPY_SAMPLES=true
+#       ;;
+#     --toree-interpreters)
+#       shift
+#       INTERPRETERS=$1
+#       ;;
+#     --cached-install)
+#       USE_CACHED_DEPS=true
+#       #R_REPOS=$R_REPOS_LOCAL
+#       ;;
+#     --no-cached-install)
+#       USE_CACHED_DEPS=false
+#       R_REPOS=$R_REPOS_REMOTE
+#       ;;
+#     --no-jupyter)
+#       NO_JUPYTER=true
+#       ;;
+#     --no-jupyterhub)
+#       JUPYTER_HUB=false
+#       ;;
+#     --ssl)
+#       SSL=true
+#       ;;
+#     --update-python-packages)
+#       UPDATE_FLAG="-U"
+#       ;;
+#     --dask)
+#       INSTALL_DASK=true
+#       ;;
+#     --python3)
+#       INSTALL_PY3_PKGS=true
+#       ;;
+#     --spark-opts)
+#       shift
+#       USER_SPARK_OPTS=$1
+#       ;;
+#     --spark-version)
+#       shift
+#       APACHE_SPARK_VERSION=$1
+#       ;;
+#     --s3fs)
+#       #NOTEBOOK_DIR_S3_S3NB=false
+#       NOTEBOOK_DIR_S3_S3CONTENTS=true
+#       ;;
+#     --use-sse)
+#       USE_SSE=true
+#       ;;
+#     --kms-id)
+#       shift
+#       KMS_ID=$1
+#       ;;
+#     #--s3nb) # this stopped working after Jupyter update in early 2017
+#     #  NOTEBOOK_DIR_S3_S3NB=true
+#     #  ;;
+#     -*)
+#       # do not exit out, just note failure
+#       error_msg "unrecognized option: $1"
+#       ;;
+#     *)
+#       break;
+#       ;;
+#     esac
+#     shift
+# done
+
+# echo '### JUPYTER_INSTALLER.SH ###'
+
+
+# sudo bash -c 'echo "fs.file-max = 25129162" >> /etc/sysctl.conf'
+# sudo sysctl -p /etc/sysctl.conf
+# sudo bash -c 'echo "* soft    nofile          1048576" >> /etc/security/limits.conf'
+# sudo bash -c 'echo "* hard    nofile          1048576" >> /etc/security/limits.conf'
+# sudo bash -c 'echo "session    required   pam_limits.so" >> /etc/pam.d/su'
+
+# sudo puppet module install spantree-upstart
+
+# RELEASE=$(cat /etc/system-release)
+# REL_NUM=$(ruby -e "puts '$RELEASE'.split.last")
+
+# echo ### ${USE_CACHED_DEPS} ###
+# if [ "$USE_CACHED_DEPS" = true ]; then
+#   cd /mnt
+#   aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/jupyter-deps.zip .
+#   aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/yum-rpm-cache-$REL_NUM.zip .
+#   unzip jupyter-deps.zip
+#   unzip yum-rpm-cache-$REL_NUM.zip
+#   rm jupyter-deps.zip
+#   rm yum-rpm-cache-$REL_NUM.zip
+# fi
+
+# echo ### ${R_REPOS} = ${R_REPOS_LOCAL} ###
+# if [ "$R_REPOS" = "$R_REPOS_LOCAL" ]; then
+#   cd /mnt
+#   #aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/miniCRAN-20170516.zip miniCRAN.zip
+#   aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/miniCRAN.zip miniCRAN.zip
+#   unzip miniCRAN.zip
+#   rm miniCRAN.zip
+# fi
+
+# # sudo mkdir -p /mnt/var/aws/emr
+# # sudo cp -pr /var/aws/emr/packages /mnt/var/aws/emr/ && sudo rm -rf /var/aws/emr/packages && sudo mkdir /var/aws/emr/packages && sudo mount -o bind /mnt/var/aws/emr/packages /var/aws/emr/packages &
+
+# # # move /usr/local and usr/share to /mnt/usr-moved/ to avoid running out of space on /
+# # if [ ! -d /mnt/usr-moved ]; then
+# #   echo "move local start" >> /tmp/install_time.log
+# #   date >> /tmp/install_time.log
+# #   sudo mkdir /mnt/usr-moved
+# #   sudo mv /usr/local /mnt/usr-moved/ && sudo ln -s /mnt/usr-moved/local /usr/
+# #   echo "move local end, move share start" >> /tmp/install_time.log
+# #   date >> /tmp/install_time.log
+# #   sudo mv /usr/share /mnt/usr-moved/ && sudo ln -s /mnt/usr-moved/share /usr/
+# #   echo "move share end" >> /tmp/install_time.log
+# #   date >> /tmp/install_time.log
+# # fi
+
+# export MAKE="make -j $NPROC"
+
+# echo ### ${USE_CACHED_DEPS} ###
+# sudo yum remove -y kernel-4.9.27-14.31.amzn1.x86_64 # EMR 5.6
+# if [ "$USE_CACHED_DEPS" = true ]; then
+#   sudo yum install -y libcurl-devel # workaround for EMR 5.9 until libcurl cache is fixed
+#   sudo yum install --skip-broken -y /mnt/yum-rpm-cache/*
+# else
+#   sudo yum install -y xorg-x11-xauth.x86_64 xorg-x11-server-utils.x86_64 xterm libXt libX11-devel libXt-devel libcurl libcurl-devel git graphviz cyrus-sasl cyrus-sasl-devel readline readline-devel gnuplot
+#   sudo yum install --enablerepo=epel -y nodejs npm zeromq3 zeromq3-devel
+#   sudo npm config set strict-ssl false
+#   sudo npm config set registry http://registry.npmjs.org/
+#   sudo yum install -y gcc-c++ patch zlib zlib-devel
+#   sudo  yum install -y libyaml-devel libffi-devel openssl-devel make
+#   sudo yum install -y bzip2 autoconf automake libtool bison iconv-devel sqlite-devel
+# fi
+
+# echo ### ${PYTHON3} ###
+# cd /mnt
+# PYTHON3=false
+# if [ "$PYTHON3" = true ]; then # this will break bigtop/puppet which relies on python 2, so disable with the line above
+#   export PYSPARK_PYTHON="python3"
+#   sudo python3 -m pip install --upgrade pip
+#   if [ -f /usr/bin/python3.4 ]; then
+#     sudo ln -sf /usr/bin/python3.4 /usr/bin/python
+#   fi
+#   if [ -f /usr/bin/pip-3.4 ]; then
+#     sudo ln -sf /usr/bin/pip-3.4 /usr/bin/pip
+#   fi
+# else
+#   sudo python -m pip install --upgrade pip
+#   if [ -f /usr/bin/pip-2.7 ]; then
+#     sudo ln -sf /usr/bin/pip-2.7 /usr/bin/pip
+#   fi
+# fi
+
+# echo ### ${JS_KERNEL} ###
+# export NODE_PATH='/usr/lib/node_modules'
+# if [ "$JS_KERNEL" = true ]; then
+#   sudo python -m pip install jinja2 tornado jsonschema pyzmq
+#   # the following no longer working or needed on the latest EMR version 5.10
+#   #sudo npm cache clean -f
+#   #sudo npm install -g npm
+#   #sudo npm install -g n
+#   #sudo n stable
+# fi
+
+# TF_BINARY_URL_PY3="https://storage.googleapis.com/tensorflow/linux/$CPU_GPU/tensorflow$GPUU-1.6.0-cp34-cp34m-linux_x86_64.whl"
+# TF_BINARY_URL="https://storage.googleapis.com/tensorflow/linux/$CPU_GPU/tensorflow$GPUU-1.6.0-cp27-none-linux_x86_64.whl"
+
+# echo ### ${INSTALL_PY3_PKGS} ###
+# sudo python3 -m pip install jupyter
+# sudo ln -sf /usr/local/bin/ipython /usr/bin/
+# sudo ln -sf /usr/local/bin/jupyter /usr/bin/
+# if [ "$INSTALL_PY3_PKGS" = true ]; then
+#   sudo python3 -m pip install matplotlib seaborn bokeh cython networkx findspark
+#   sudo python3 -m pip install pyhive sasl thrift thrift-sasl snakebite
+#   # sudo python3 -m pip install google-cloud==0.32.0 mrjob || true # workaround the possible failure
+# else
+#   sudo python -m pip install matplotlib seaborn bokeh cython networkx findspark
+#   sudo python -m pip install pyhive sasl thrift thrift-sasl snakebite --ignore-installed chardet
+#   # sudo python -m pip install google-cloud==0.32.0 mrjob || true # workaround the possible failure
+# fi
+
+# echo ### ${DS_PACKAGES} ###
+# if [ "$DS_PACKAGES" = true ]; then
+#   # Python
+#   if [ "$INSTALL_PY3_PKGS" = true ]; then
+#     sudo python3 -m pip install scikit-learn pandas numpy numexpr statsmodels scipy
+#   else
+#     sudo python -m pip install scikit-learn pandas numpy numexpr statsmodels scipy    
+#   fi
+#   # Javascript
+#   if [ "$JS_KERNEL" = true ]; then
+#     sudo npm install -g --unsafe-perm stats-analysis decision-tree machine_learning limdu synaptic node-svm lda brain.js scikit-node
+#   fi
+# fi
+
+# echo ### ${ML_PACKAGES} ###
+# if [ "$ML_PACKAGES" = true ]; then
+#   if [ "$INSTALL_PY3_PKGS" = true ]; then
+#     sudo python3 -m pip install mxnet sagemaker
+#     sudo python3 -m pip install $TF_BINARY_URL_PY3
+#     sudo python3 -m pip install theano
+#     sudo python3 -m pip install keras
+#     sudo python3 -m pip install xgboost lightgbm opencv-python
+#     #sudo python3 -m pip install pytorch # pytorch taking too long to setup, skip it for now
+#   else
+#     sudo python -m pip install mxnet sagemaker
+#     sudo python -m pip install $TF_BINARY_URL
+#     sudo python -m pip install theano
+#     sudo python -m pip install keras
+#     sudo python -m pip install xgboost lightgbm opencv-python
+#     #sudo python3 -m pip install pytorch # pytorch taking too long to setup, skip it for now
+#   fi
+# fi
+
+# echo ### ${PYTHON_PACKAGES} ###
+# if [ ! "$PYTHON_PACKAGES" = "" ]; then
+#   if [ "$INSTALL_PY3_PKGS" = true ]; then
+#     sudo python3 -m pip install $PYTHON_PACKAGES || true
+#   else
+#     sudo python -m pip install $PYTHON_PACKAGES || true
+#   fi
+# fi
+
+# echo ### ${BIGDL} ###
+# if [ "$BIGDL" = true ]; then
+#   aws s3 cp s3://tomzeng/maven/apache-maven-3.3.3-bin.tar.gz .
+#   tar xvfz apache-maven-3.3.3-bin.tar.gz
+#   sudo mv apache-maven-3.3.3 /opt/maven
+#   sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
+
+#   git clone https://github.com/intel-analytics/BigDL.git
+#   cd BigDL/
+#   export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
+#   export BIGDL_HOME=/mnt/BigDL
+#   export BIGDL_VER="0.6.0-SNAPSHOT"
+#   bash make-dist.sh -P spark_2.x,scala_2.11
+#   mkdir /tmp/bigdl_summaries
+#   /usr/local/bin/tensorboard --debug INFO --logdir /tmp/bigdl_summaries/ > /tmp/tensorboard_bigdl.log 2>&1 &
+# fi
+
+# echo ### ${JULIA_KERNEL} ###
+
+# if [ "$JULIA_KERNEL" = true ]; then
+#   # Julia install
+#   cd /mnt
+#   if [ ! "$USE_CACHED_DEPS" = true ]; then
+#     #wget https://julialang.s3.amazonaws.com/bin/linux/x64/0.5/julia-0.5.0-linux-x86_64.tar.gz # julia-3c9d75391c
+#     #wget https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.1-linux-x86_64.tar.gz # julia-0d7248e2ff
+#     #wget https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.2-linux-x86_64.tar.gz  # julia-d386e40c17
+#     aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/julia-0.6.2-linux-x86_64.tar.gz .
+#     #tar xvfz julia-0.5.0-linux-x86_64.tar.gz
+#     #tar xvfz julia-0.6.1-linux-x86_64.tar.gz
+#     tar xvfz julia-0.6.2-linux-x86_64.tar.gz
+#   fi
+#   #cd julia-3c9d75391c
+#   #cd julia-0d7248e2ff
+#   cd julia-d386e40c17
+#   sudo cp -pr bin/* /usr/bin/
+#   sudo cp -pr lib/* /usr/lib/
+#   #sudo cp -pr libexec/* /usr/libexec/
+#   sudo cp -pr share/* /usr/share/
+#   sudo cp -pr include/* /usr/include/
+# fi
+
+# echo ### ${INSTALL_DASK} ###
+# if [ "$INSTALL_DASK" = true ]; then
+#   if [ "$INSTALL_PY3_PKGS" = true ]; then
+#     sudo python3 -m pip install dask[complete] distributed
+#   else
+#     sudo python -m pip install dask[complete] distributed
+#   fi
+#   export PATH=$PATH:/usr/local/bin
+#   if [ "$IS_MASTER" = true ]; then
+#     dask-scheduler > /var/log/dask-scheduler.log 2>&1 &
+#   else
+#     MASTER_KV=$(grep masterHost /emr/instance-controller/lib/info/job-flow-state.txt)
+#     MASTER_HOST=$(ruby -e "puts '$MASTER_KV'.gsub('\"','').split.last")
+#     dask-worker $MASTER_HOST:8786 > /var/log/dask-worker.log 2>&1 &
+#   fi
+# fi
+
+# #echo ". /mnt/ipython-env/bin/activate" >> ~/.bashrc
+
+# # only run below on master instance
+# if [ "$IS_MASTER" = true ]; then
+# echo ### ${RUBY_KERNEL} ###
+# if [ "$RUBY_KERNEL" = true ]; then
+#   cd /mnt
+#   if [ "$USE_CACHED_DEPS" != true ]; then
+#     #wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz
+#     wget https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.0.tar.gz
+#     #tar xvzf ruby-2.1.8.tar.gz
+#     tar xvzf ruby-2.5.0.tar.gz
+#   fi
+#   #cd ruby-2.1.8
+#   cd ruby-2.5.0
+#   ./configure --prefix=/usr
+#   make -j $NPROC
+#   sudo make install
+#   #sudo gem install puppet -v=3.7.4 -N
+#   sudo gem install rbczmq iruby -N
+#   sudo gem install presto-client -N
+#   sudo iruby register
+#   sudo cp -pr /root/.ipython/kernels/ruby /usr/local/share/jupyter/kernels/
+#   iruby register
+# fi
+
+# sudo mkdir -p /var/log/jupyter
+# mkdir -p ~/.jupyter
+# touch ~/.jupyter/jupyter_notebook_config.py
+
+# sed -i '/c.NotebookApp.open_browser/d' ~/.jupyter/jupyter_notebook_config.py
+# echo "c.NotebookApp.open_browser = False" >> ~/.jupyter/jupyter_notebook_config.py
+
+# if [ ! "$JUPYTER_LOCALHOST_ONLY" = true ]; then
+# sed -i '/c.NotebookApp.ip/d' ~/.jupyter/jupyter_notebook_config.py
+# echo "c.NotebookApp.ip='*'" >> ~/.jupyter/jupyter_notebook_config.py
+# fi
+
+# sed -i '/c.NotebookApp.port/d' ~/.jupyter/jupyter_notebook_config.py
+# echo "c.NotebookApp.port = $JUPYTER_PORT" >> ~/.jupyter/jupyter_notebook_config.py
+
+# echo ### ${JUPYTER_PASSWORD} ###
+# if [ ! "$JUPYTER_PASSWORD" = "" ]; then
+#   sed -i '/c.NotebookApp.password/d' ~/.jupyter/jupyter_notebook_config.py
+#   HASHED_PASSWORD=$(python3 -c "from notebook.auth import passwd; print(passwd('$JUPYTER_PASSWORD'))")
+#   echo "c.NotebookApp.password = u'$HASHED_PASSWORD'" >> ~/.jupyter/jupyter_notebook_config.py
+# else
+#   sed -i '/c.NotebookApp.token/d' ~/.jupyter/jupyter_notebook_config.py
+#   echo "c.NotebookApp.token = u''" >> ~/.jupyter/jupyter_notebook_config.py
+# fi
+
+# echo "c.Authenticator.admin_users = {'$JUPYTER_HUB_DEFAULT_USER'}" >> ~/.jupyter/jupyter_notebook_config.py
+# echo "c.LocalAuthenticator.create_system_users = True" >> ~/.jupyter/jupyter_notebook_config.py
+
+# echo ### ${SSL} ###
+
+# if [ "$SSL" = true ]; then
+#   #NOTE - replace server.cert and server.key with your own cert and key files
+#   CERT=/usr/local/etc/server.cert
+#   KEY=/usr/local/etc/server.key
+#   sudo openssl req -x509 -nodes -days 3650 -newkey rsa:1024 -keyout $KEY -out $CERT -subj "/C=US/ST=Washington/L=Seattle/O=JupyterCert/CN=JupyterCert"
+  
+#   # the following works for Jupyter but will fail JupyterHub, use options for both instead
+#   #echo "c.NotebookApp.certfile = u'/usr/local/etc/server.cert'" >> ~/.jupyter/jupyter_notebook_config.py
+#   #echo "c.NotebookApp.keyfile = u'/usr/local/etc/server.key'" >> ~/.jupyter/jupyter_notebook_config.py
+
+#   SSL_OPTS_JUPYTER="--keyfile=/usr/local/etc/server.key --certfile=/usr/local/etc/server.cert"
+#   SSL_OPTS_JUPYTERHUB="--ssl-key=/usr/local/etc/server.key --ssl-cert=/usr/local/etc/server.cert"
+# fi
+
+# # install default kernels
+# sudo python3 -m pip install $UPDATE_FLAG notebook ipykernel
+# sudo python3 -m pip install tornado==4.5.3 # fix the latest tonardo and asyncio package conflict
+# sudo python3 -m ipykernel install
+# sudo python -m pip install $UPDATE_FLAG notebook ipykernel
+# sudo python -m ipykernel install
+# sudo python3 -m pip install metakernel
+# #sudo python3 -m pip install gnuplot_kernel
+# #sudo python3 -m gnuplot_kernel install
+# sudo python3 -m pip install bash_kernel
+# sudo python3 -m bash_kernel.install
+
+# echo ### ${JS_KERNEL} ###
+
+# # Javascript/CoffeeScript kernels
+# if [ "$JS_KERNEL" = true ]; then
+#   sudo npm install -g --unsafe-perm ijavascript d3 lodash plotly jp-coffeescript
+#   sudo ijs --ijs-install=global
+#   sudo jp-coffee --jp-install=global
+# fi
+# sudo python3 -m pip install $UPDATE_FLAG jupyter_contrib_nbextensions
+# sudo python -m pip install $UPDATE_FLAG jupyter_contrib_nbextensions
+# sudo python3 -m pip install -U six
+# sudo python -m pip install -U six
+# sudo jupyter contrib nbextension install --system
+# sudo python3 -m pip install $UPDATE_FLAG jupyter_nbextensions_configurator
+# sudo python -m pip install $UPDATE_FLAG jupyter_nbextensions_configurator
+# sudo jupyter nbextensions_configurator enable --system
+# sudo python3 -m pip install $UPDATE_FLAG ipywidgets
+# sudo python -m pip install $UPDATE_FLAG ipywidgets
+# sudo jupyter nbextension enable --py --sys-prefix widgetsnbextension
+
+# sudo python3 -m pip install pyeda # only work for python3
+# sudo python -m pip install gvmagic py_d3
+# sudo python -m pip install ipython-sql
+
+# echo ### ${JULIA_KERNEL} ###
+
+# if [ "$JULIA_KERNEL" = true ]; then
+#   julia -e 'Pkg.add("IJulia")'
+#   julia -e 'Pkg.add("RDatasets");Pkg.add("Gadfly");Pkg.add("DataFrames");Pkg.add("PyPlot")'
+#   # Julia's Spark support does not support Spark on Yarn yet
+#   # install mvn
+#   #cd /mnt
+#   #aws s3 cp s3://tomzeng/maven/apache-maven-3.3.9-bin.tar.gz .
+#   #tar xvfz apache-maven-3.3.9-bin.tar.gz
+#   #sudo mv apache-maven-3.3.9 /opt/maven
+#   #sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
+#   # install Spark for Julia
+#   #julia -e 'Pkg.clone("https://github.com/dfdx/Spark.jl"); Pkg.build("Spark"); Pkg.checkout("JavaCall")'
+# fi
+
+# echo ### ${TORCH_KERNEL} ###
+
+# # iTorch depends on Torch which is installed with --ml-packages
+# if [ "$TORCH_KERNEL" = true ]; then
+#   set +e # workaround for the lengthy torch install-deps, esp when other background process are also running yum
+#   cd /mnt
+#   if [ ! "$USE_CACHED_DEPS" = true ]; then
+#     git clone https://github.com/torch/distro.git torch-distro
+#   fi
+#   cd torch-distro
+#   git pull
+#   ./install-deps
+#   ./install.sh -b
+#   export PATH=$PATH:/mnt/torch-distro/install/bin
+#   source ~/.profile
+#   luarocks install lzmq
+#   luarocks install gnuplot
+#   cd /mnt
+#   if [ ! "$USE_CACHED_DEPS" = true ]; then
+#     git clone https://github.com/facebook/iTorch.git
+#   fi
+#   cd iTorch
+#   luarocks make
+#   #sudo env "PATH=$PATH:/usr/local/bin" luarocks make install
+#   #sudo chown -R $USER $(dirname $(ipython locate profile))
+#   sudo cp -pr ~/.ipython/kernels/itorch /usr/local/share/jupyter/kernels/
+#   set -e
+# fi
+
+# echo ### ${R_KERNEL} n ${TOREE_KERNEL} ###
+
+# if [ "$R_KERNEL" = true ] || [ "$TOREE_KERNEL" = true ]; 
+# then
+#   sudo yum install -y R-devel readline-dev
+#   sudo ln -s /usr/lib/gcc/x86_64-amazon-linux/6.4.1/libgomp.spec /usr/lib64/libgomp.spec
+#   sudo ln -s /usr/lib/gcc/x86_64-amazon-linux/6.4.1/libgomp.a /usr/lib64/libgomp.a
+#   sudo ln -s /usr/lib64/libgomp.so.1.0.0 /usr/lib64/libgomp.so
+#   aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/rpy2-2.8.6.tar.gz /mnt/
+#   sudo python -m pip install -Iv /mnt/rpy2-2.8.6.tar.gz
+
+#   if [ ! -f /tmp/Renvextra ]; then # check if the rstudio ba was run, it does this already 
+#    sudo sed -i "s/make/make -j $NPROC/g" /usr/lib64/R/etc/Renviron
+#   fi
+
+#   sudo R --no-save << R_SCRIPT
+#     #install.packages(c('devtools', 'RJSONIO', 'itertools', 'digest', 'Rcpp', 'functional', 'httr', 'plyr', 'stringr', 'reshape2', 'caTools', 'rJava', 'DBI', 'ggplot2', 'dplyr', 'R.methodsS3', 'Hmisc', 'memoise', 'rjson'), repos="$R_REPOS", quiet = FALSE)
+#     install.packages(c('devtools'), repos="$R_REPOS", quiet = FALSE)
+#     # For the Granger Causuality example deps
+#     library(devtools)
+#     #install.packages(c('fUnitRoots','vars','aod','tseries'), repos="$R_REPOS", quiet = FALSE)
+# R_SCRIPT
+# fi
+
+# # IRKernal setup 
+# if [ "$R_KERNEL" = true ]; then
+#   sudo R --no-save << R_SCRIPT
+#     install.packages(c("devtools","XML","readr","httr","RCurl","data.table","parallel","tidyverse","dplyr","knitr","gplots","tidyr","shiny","ggplot2","rlist","ggthemes","lubridate","Rcpp","reshape", "RJSONIO", "itertools", "digest", "functional", "httr", "plyr", "stringr", "reshape2", "caTools", "rJava", "DBI", "R.methodsS3", "Hmisc", "memoise", "rjson", "IRdisplay", "evaluate", "crayon", "pbdZMQ", "uuid", "digest", "e1071", "party"), repos="$R_REPOS", quiet = TRUE)
+#     devtools::install_github("IRkernel/IRkernel")
+#     IRkernel::installspec(user = FALSE)
+# R_SCRIPT
+# fi
+
+# echo ### ${NOTEBOOK_DIR} ###
+
+# if [ ! "$NOTEBOOK_DIR" = "" ]; then
+#   NOTEBOOK_DIR="${NOTEBOOK_DIR%/}/" # remove trailing / if exists then add /
+#   if [[ "$NOTEBOOK_DIR" == s3://* ]]; then
+#     NOTEBOOK_DIR_S3=true
+#     # the s3nb does not fully working yet(upload and createe folder not working)
+#     # s3nb does not work anymore due to Jupyter update
+#     if [ "$NOTEBOOK_DIR_S3_S3NB" = true ]; then
+#       cd /mnt
+#       if [ ! "$USE_CACHED_DEPS" = true ]; then
+#         git clone https://github.com/tomz/s3nb.git
+#       fi
+#       cd s3nb
+#       sudo python -m pip install entrypoints
+#       sudo python setup.py install
+#       if [ "$JUPYTER_HUB" = true ]; then
+#         sudo python3 -m pip install entrypoints
+#         sudo python3 setup.py install
+#       fi
+
+#       echo "c.NotebookApp.contents_manager_class = 's3nb.S3ContentsManager'" >> ~/.jupyter/jupyter_notebook_config.py
+#       echo "c.S3ContentsManager.checkpoints_kwargs = {'root_dir': '~/.checkpoints'}" >> ~/.jupyter/jupyter_notebook_config.py
+#       # if just bucket with no subfolder, a trailing / is required, otherwise s3nb will break
+#       echo "c.S3ContentsManager.s3_base_uri = '$NOTEBOOK_DIR'" >> ~/.jupyter/jupyter_notebook_config.py
+#       #echo "c.S3ContentsManager.s3_base_uri = '${NOTEBOOK_DIR_S3%/}/%U'" >> ~/.jupyter/jupyter_notebook_config.py
+#       #echo "c.Spawner.default_url = '${NOTEBOOK_DIR_S3%/}/%U'" >> ~/.jupyter/jupyter_notebook_config.py
+#       #echo "c.Spawner.notebook_dir = '/%U'" >> ~/.jupyter/jupyter_notebook_config.py 
+#     elif [ "$NOTEBOOK_DIR_S3_S3CONTENTS" = true ]; then
+#       BUCKET=$(ruby -e "puts '$NOTEBOOK_DIR'.split('//')[1].split('/')[0]")
+#       FOLDER=$(ruby -e "puts '$NOTEBOOK_DIR'.split('//')[1].split('/')[1..-1].join('/')")
+#       #sudo python -m pip install s3contents
+#       cd /mnt
+#       #aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/s3contents.zip .
+#       #unzip s3contents.zip
+#       git clone https://github.com/tomz/s3contents.git
+#       cd s3contents
+#       sudo python setup.py install
+#       echo "c.NotebookApp.contents_manager_class = 's3contents.S3ContentsManager'" >> ~/.jupyter/jupyter_notebook_config.py
+#       echo "c.S3ContentsManager.bucket_name = '$BUCKET'" >> ~/.jupyter/jupyter_notebook_config.py
+#       echo "c.S3ContentsManager.prefix = '$FOLDER'" >> ~/.jupyter/jupyter_notebook_config.py
+#       # this following is no longer needed, default was fixed in the latest on github
+#       #echo "c.S3ContentsManager.endpoint_url = 'https://s3.amazonaws.com'" >> ~/.jupyter/jupyter_notebook_config.py
+#     else
+#       BUCKET=$(ruby -e "puts '$NOTEBOOK_DIR'.split('//')[1].split('/')[0]")
+#       FOLDER=$(ruby -e "puts '$NOTEBOOK_DIR'.split('//')[1].split('/')[1..-1].join('/')")
+#       if [ "$USE_CACHED_DEPS" != true ]; then
+#         sudo yum install -y automake fuse fuse-devel libxml2-devel
+#       fi
+#       cd /mnt
+#       git clone https://github.com/s3fs-fuse/s3fs-fuse.git
+#       cd s3fs-fuse/
+#       ls -alrt
+#       ./autogen.sh
+#       ./configure
+#       make -j $NPROC
+#       sudo make install
+#       sudo su -c 'echo user_allow_other >> /etc/fuse.conf'
+#       mkdir -p /mnt/s3fs-cache
+#       mkdir -p /mnt/$BUCKET
+#       #/usr/local/bin/s3fs -o allow_other -o iam_role=auto -o umask=0 $BUCKET /mnt/$BUCKET
+#       # -o nodnscache -o nosscache -o parallel_count=20  -o multipart_size=50
+#       S3SSE_FLAG=""
+#       if [ "$USE_SSE" = true ]; then
+#         if [ ! "KMS_ID" = "" ]; then
+#           S3SSE_FLAG = "-o use_sse='kmsid:$KMS_ID'"
+#         else
+#           S3SSE_FLAG = "-o use_sse"
+#         fi
+#       fi
+#       /usr/local/bin/s3fs -o allow_other -o iam_role=auto -o umask=0 -o url=https://s3.amazonaws.com  -o no_check_certificate -o enable_noobj_cache -o use_cache=/mnt/s3fs-cache $S3SSE_FLAG $BUCKET /mnt/$BUCKET
+#       if [ "$JUPYTER_HUB" = true ]; then
+#         mkdir -p /mnt/$BUCKET/$FOLDER/${JUPYTER_HUB_DEFAULT_USER}
+#       fi
+#       #/usr/local/bin/s3fs -o allow_other -o iam_role=auto -o umask=0 -o use_cache=/mnt/s3fs-cache $BUCKET /mnt/$BUCKET
+#       echo "c.NotebookApp.notebook_dir = '/mnt/$BUCKET/$FOLDER'" >> ~/.jupyter/jupyter_notebook_config.py
+#       echo "c.ContentsManager.checkpoints_kwargs = {'root_dir': '.checkpoints'}" >> ~/.jupyter/jupyter_notebook_config.py
+#       if [ "$JUPYTER_HUB" = true ]; then
+#         echo "try:" >> ~/.jupyter/jupyter_notebook_config.py
+#         echo "  from jupyterhub.spawner import LocalProcessSpawner" >> ~/.jupyter/jupyter_notebook_config.py
+#         echo "  class MySpawner(LocalProcessSpawner):" >> ~/.jupyter/jupyter_notebook_config.py
+#         echo "      def _notebook_dir_default(self):" >> ~/.jupyter/jupyter_notebook_config.py
+#         echo "        return c.NotebookApp.notebook_dir + '/' + self.user.name" >> ~/.jupyter/jupyter_notebook_config.py
+#         echo "  c.JupyterHub.spawner_class = MySpawner" >> ~/.jupyter/jupyter_notebook_config.py 
+#         echo "except:" >> ~/.jupyter/jupyter_notebook_config.py
+#         echo "  print('jupyterhub module not found')" >> ~/.jupyter/jupyter_notebook_config.py
+#       fi
+#     fi
+#   else
+#     echo "c.NotebookApp.notebook_dir = '$NOTEBOOK_DIR'" >> ~/.jupyter/jupyter_notebook_config.py
+#     echo "c.ContentsManager.checkpoints_kwargs = {'root_dir': '.checkpoints'}" >> ~/.jupyter/jupyter_notebook_config.py
+#   fi
+# fi
+
+# echo '### ${JUPYTER_HUB_DEFAULT_USER} ###'
+
+# if [ ! "$JUPYTER_HUB_DEFAULT_USER" = "" ]; then
+#   sudo adduser $JUPYTER_HUB_DEFAULT_USER
+# fi
+
+# echo ### ${COPY_SAMPLES} ###
+# if [ "$COPY_SAMPLES" = true ]; then
+#   cd ~
+#   if [ "$NOTEBOOK_DIR_S3" = true ]; then
+#     aws s3 sync s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/notebooks/ ${NOTEBOOK_DIR}samples/ || true
+#     if [ "$JUPYTER_HUB" = true ]; then
+#       aws s3 sync s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/notebooks/ ${NOTEBOOK_DIR}${JUPYTER_HUB_DEFAULT_USER}/samples/ || true
+#     fi
+#   else
+#     if [ ! "$NOTEBOOK_DIR" = "" ]; then
+#       mkdir -p ${NOTEBOOK_DIR}samples || true
+#       sudo mkdir /home/$JUPYTER_HUB_DEFAULT_USER/${NOTEBOOK_DIR}samples || true
+#     fi
+#     aws s3 sync s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/notebooks/ ${NOTEBOOK_DIR}samples || true
+#     sudo cp -pr ${NOTEBOOK_DIR}samples /home/$JUPYTER_HUB_DEFAULT_USER/
+#     sudo chown -R $JUPYTER_HUB_DEFAULT_USER:$JUPYTER_HUB_DEFAULT_USER /home/$JUPYTER_HUB_DEFAULT_USER/${NOTEBOOK_DIR}samples
+#   fi
+# fi
+
+
+# wait_for_spark() {
+#   while [ ! -f /var/run/spark/spark-history-server.pid ]
+#   do
+#     sleep 10
+#   done
+# }
+
+# setup_jupyter_process_with_bigdl() {
+#   wait_for_spark
+#   export PYTHON_API_PATH=${BIGDL_HOME}/dist/lib/bigdl-$BIGDL_VER-python-api.zip
+#   export BIGDL_JAR_PATH=${BIGDL_HOME}/dist/lib/bigdl-$BIGDL_VER-jar-with-dependencies.jar
+#   cat ${BIGDL_HOME}/dist/conf/spark-bigdl.conf | sudo tee -a /etc/spark/conf/spark-defaults.conf
+# #   sudo puppet apply << PUPPET_SCRIPT
+# #   include 'upstart'
+# #   upstart::job { 'jupyter':
+# #     description    => 'Jupyter',
+# #     respawn        => true,
+# #     respawn_limit  => '0 10',
+# #     start_on       => 'runlevel [2345]',
+# #     stop_on        => 'runlevel [016]',
+# #     console        => 'output',
+# #     chdir          => '/home/hadoop',
+# #     script           => '
+# #     sudo su - hadoop > /var/log/jupyter/jupyter.log 2>&1 <<BASH_SCRIPT
+# #     export NODE_PATH="$NODE_PATH"
+# #     export PYSPARK_DRIVER_PYTHON="jupyter"
+# #     export PYSPARK_DRIVER_PYTHON_OPTS="notebook --no-browser $SSL_OPTS_JUPYTER --log-level=INFO"
+# #     export NOTEBOOK_DIR="$NOTEBOOK_DIR"
+
+# #     export BIGDL_HOME=/mnt/BigDL
+# #     export SPARK_HOME=/usr/lib/spark
+# #     export YARN_CONF_DIR=/etc/hadoop/conf
+# #     export PYTHONPATH=${PYTHON_API_PATH}:$PYTHONPATH
+# #     source ${BIGDL_HOME}/dist/bin/bigdl.sh
+# #     #pyspark --py-files ${PYTHON_API_PATH} --jars ${BIGDL_JAR_PATH} --conf spark.driver.extraClassPath=${BIGDL_JAR_PATH} --conf spark.executor.extraClassPath=bigdl-${BIGDL_VER}-jar-with-dependencies.jar
+# #     pyspark --py-files ${PYTHON_API_PATH} --jars ${BIGDL_JAR_PATH}
+# # BASH_SCRIPT
+# #     ',
+# #   }
+# # PUPPET_SCRIPT
+# }
+
+# background_install_proc() {
+#   wait_for_spark
+  
+#   if ! grep "spark.sql.catalogImplementation" /etc/spark/conf/spark-defaults.conf; then
+#     sudo bash -c "echo 'spark.sql.catalogImplementation  hive' >> /etc/spark/conf/spark-defaults.conf"
+#   fi
+  
+#   if [ ! -f /tmp/Renvextra ]; then # check if the rstudio BA maybe already done this
+#     cat << 'EOF' > /tmp/Renvextra
+# JAVA_HOME="/etc/alternatives/jre"
+# HADOOP_HOME_WARN_SUPPRESS="true"
+# HADOOP_HOME="/usr/lib/hadoop"
+# HADOOP_PREFIX="/usr/lib/hadoop"
+# HADOOP_MAPRED_HOME="/usr/lib/hadoop-mapreduce"
+# HADOOP_YARN_HOME="/usr/lib/hadoop-yarn"
+# HADOOP_COMMON_HOME="/usr/lib/hadoop"
+# HADOOP_HDFS_HOME="/usr/lib/hadoop-hdfs"
+# HADOOP_CONF_DIR="/usr/lib/hadoop/etc/hadoop"
+# YARN_CONF_DIR="/usr/lib/hadoop/etc/hadoop"
+# YARN_HOME="/usr/lib/hadoop-yarn"
+# HIVE_HOME="/usr/lib/hive"
+# HIVE_CONF_DIR="/usr/lib/hive/conf"
+# HBASE_HOME="/usr/lib/hbase"
+# HBASE_CONF_DIR="/usr/lib/hbase/conf"
+# SPARK_HOME="/usr/lib/spark"
+# SPARK_CONF_DIR="/usr/lib/spark/conf"
+# PATH=${PWD}:${PATH}
+# EOF
+
+#   #if [ "$PYSPARK_PYTHON" = "python3" ]; then
+#   if [ "$INSTALL_PY3_PKGS" = true ]; then
+#     cat << 'EOF' >> /tmp/Renvextra
+# PYSPARK_PYTHON="python3"
+# EOF
+#   fi
+
+#   cat /tmp/Renvextra | sudo tee -a /usr/lib64/R/etc/Renviron
+
+#   sudo mkdir -p /mnt/spark
+#   sudo chmod a+rwx /mnt/spark
+#   if [ -d /mnt1 ]; then
+#     sudo mkdir -p /mnt1/spark
+#     sudo chmod a+rwx /mnt1/spark
+#   fi
+
+#   sudo R --no-save << R_SCRIPT
+#   library(devtools)
+#   devtools::install_github("rstudio/sparklyr")
+#   install.packages(c('nycflights13', 'Lahman', 'data.table'), repos="$R_REPOS", quiet = TRUE)
+# R_SCRIPT
+
+#   set +e # workaround for if SparkR is already installed by other BA
+#   # install SparkR and SparklyR for R - toree ifself does not need this
+#   sudo R --no-save << R_SCRIPT
+#   library(devtools)
+#   install('/usr/lib/spark/R/lib/SparkR')
+# R_SCRIPT
+#   set -e
+
+#   fi # end if -f /tmp/Renvextra
+
+#   sudo python3 -m pip install /mnt/incubator-toree/dist/toree-pip
+
+#   #sudo ln -sf /usr/local/bin/jupyter-toree /usr/bin/
+#   export SPARK_HOME="/usr/lib/spark"
+#   SPARK_PACKAGES=""
+
+#   PYSPARK_PYTHON="python3"
+  
+#   if [ ! "$USER_SPARK_OPTS" = "" ]; then
+#     SPARK_OPTS=$USER_SPARK_OPTS
+#     SPARK_PACKAGES=$(ruby -e "opts='$SPARK_OPTS'.split;pkgs=nil;opts.each_with_index{|o,i| pkgs=opts[i+1] if o.start_with?('--packages')};puts pkgs || '$SPARK_PACKAGES'")
+#     export SPARK_OPTS
+#     export SPARK_PACKAGES
+    
+#     sudo jupyter toree install --interpreters=$INTERPRETERS --spark_home=$SPARK_HOME --python_exec=$PYSPARK_PYTHON --spark_opts="$SPARK_OPTS"
+#     # NOTE - toree does not pick SPARK_OPTS, so use the following workaround until it's fixed  
+#     if [ ! "$SPARK_PACKAGES" = "" ]; then
+#       if ! grep "spark.jars.packages" /etc/spark/conf/spark-defaults.conf; then
+#         sudo bash -c "echo 'spark.jars.packages              $SPARK_PACKAGES' >> /etc/spark/conf/spark-defaults.conf"
+#       fi
+#     fi
+#   else
+#     sudo jupyter toree install --interpreters=$INTERPRETERS --spark_home=$SPARK_HOME --python_exec=$PYSPARK_PYTHON
+#   fi
+
+  
+#   if [ "$INSTALL_PY3_PKGS" = true ]; then
+#     sudo bash -c 'echo "" >> /etc/spark/conf/spark-env.sh'
+#     sudo bash -c 'echo "export PYSPARK_PYTHON=/usr/bin/python3" >> /etc/spark/conf/spark-env.sh'
+    
+#     #if [ -f /usr/local/share/jupyter/kernels/apache_toree_pyspark/kernel.json ]; then
+#     #  sudo bash -c 'sed -i "s/\"PYTHON_EXEC\": \"python\"/\"PYTHON_EXEC\": \"\/usr\/bin\/python3\"/g" /usr/local/share/jupyter/kernels/apache_toree_pyspark/kernel.json'
+#     #fi
+    
+#   fi
+  
+#   # the following dirs could cause conflict, so remove them
+#   rm -rf ~/.m2/
+#   rm -rf ~/.ivy2/
+  
+#   if [ "$NO_JUPYTER" = false ]; then
+#     echo "Starting Jupyter notebook via pyspark"
+#     cd ~
+#     #PYSPARK_DRIVER_PYTHON=jupyter PYSPARK_DRIVER_PYTHON_OPTS="notebook --no-browser" pyspark > /var/log/jupyter/jupyter.log &
+# #    if [ "$BIGDL" = false ]; then
+# #       sudo puppet apply << PUPPET_SCRIPT
+# #       include 'upstart'
+# #       upstart::job { 'jupyter':
+# #         description    => 'Jupyter',
+# #         respawn        => true,
+# #         respawn_limit  => '0 10',
+# #         start_on       => 'runlevel [2345]',
+# #         stop_on        => 'runlevel [016]',
+# #         console        => 'output',
+# #         chdir          => '/home/hadoop',
+# #         script           => '
+# #         sudo su - hadoop > /var/log/jupyter/jupyter.log 2>&1 <<BASH_SCRIPT
+# #         export NODE_PATH="$NODE_PATH"
+# #         export PYSPARK_DRIVER_PYTHON="jupyter"
+# #         export PYSPARK_DRIVER_PYTHON_OPTS="notebook --no-browser $SSL_OPTS_JUPYTER --log-level=INFO"
+# #         export NOTEBOOK_DIR="$NOTEBOOK_DIR"
+# #         pyspark
+# # BASH_SCRIPT
+# #         ',
+# #       }
+# # PUPPET_SCRIPT
+#     # else
+#     #   setup_jupyter_process_with_bigdl
+#     # fi
+#   fi
+# }
+
+# create_hdfs_user() {
+#   wait_for_spark
+#   sudo -u hdfs hdfs dfs -mkdir /user/$JUPYTER_HUB_DEFAULT_USER
+#   sudo -u hdfs hdfs dfs -chown $JUPYTER_HUB_DEFAULT_USER:$JUPYTER_HUB_DEFAULT_USER /user/$JUPYTER_HUB_DEFAULT_USER
+#   sudo -u hdfs hdfs dfs -chmod -R 777 /user/$JUPYTER_HUB_DEFAULT_USER
+# }
+
+# # apache toree install
+# if [ "$TOREE_KERNEL" = true ]; then
+#   echo "Running background process to install Apacke Toree"
+#   # spark 1.6
+#   #sudo pip install --pre toree
+#   #sudo jupyter toree install
+
+#   # spark 2.0
+#   cd /mnt
+#   if [ "$USE_CACHED_DEPS" != true ]; then
+#     #curl https://bintray.com/sbt/rpm/rpm | sudo tee /etc/yum.repos.d/bintray-sbt-rpm.repo
+#     #sudo yum install sbt -y
+#     #binstry sbt rpm repo goes down sometimes, switch to manuall install:    
+#     aws s3 cp s3://aws-bigdata-blog/artifacts/aws-blog-emr-jupyter/sbt-1.1.1.tgz .
+#     tar xvfz sbt-1.1.1.tgz
+#     sudo mv sbt/bin/* /usr/bin/
+#     sudo mv sbt/conf /etc/sbt
+#     rm -rf sbt
+    
+#     sudo yum install docker -y
+#   fi
+#   if [ ! "$USE_CACHED_DEPS" = true ]; then
+#     git clone https://github.com/apache/incubator-toree.git
+#   fi
+#   cd incubator-toree/
+#   git pull
+#   export APACHE_SPARK_VERSION=$APACHE_SPARK_VERSION
+#   make -j $NPROC dist
+#   sed -i "s/docker run -t/sudo docker run -t/" Makefile
+#   make clean release APACHE_SPARK_VERSION=$APACHE_SPARK_VERSION || true # gettting the docker not running error, swallow it with || true
+#   if [ "$RUN_AS_STEP" = true ]; then
+#     background_install_proc
+#   else
+#     background_install_proc &
+#   fi
+# else
+#   if [ "$NO_JUPYTER" = false ]; then
+#     echo "Starting Jupyter notebook"
+#     # if [ "$BIGDL" = false ]; then
+# #       sudo puppet apply << PUPPET_SCRIPT
+# #       include 'upstart'
+# #       upstart::job { 'jupyter':
+# #           description    => 'Jupyter'
+# #           respawn        => true,
+# #           respawn_limit  => '0 10',
+# #           start_on       => 'runlevel [2345]',
+# #           stop_on        => 'runlevel [016]',
+# #           console        => 'output',
+# #           chdir          => '/home/hadoop',
+# #           env            => { 'NOTEBOOK_DIR' => '$NOTEBOOK_DIR', 'NODE_PATH' => '$NODE_PATH' },
+# #           exec           => 'sudo su - hadoop -c "jupyter notebook --no-browser $SSL_OPTS_JUPYTER" > /var/log/jupyter/jupyter.log 2>&1',
+# #       }
+# # PUPPET_SCRIPT
+#     # else
+#     #   setup_jupyter_process_with_bigdl &
+#     # fi
+#   fi
+# fi
+
+# echo '### ${JUPYTER_HUB} ###'
+# if [ "$JUPYTER_HUB" = true ]; then
+#   sudo npm install -g --unsafe-perm configurable-http-proxy
+#   sudo python3 -m pip install $UPDATE_FLAG jupyterhub #notebook ipykernel
+#   #sudo python3 -m ipykernel install
+  
+#   if [ ! "$JUPYTER_HUB_DEFAULT_USER" = "" ]; then
+#     create_hdfs_user &
+#   fi
+#   # change the password of the hadoop user to JUPYTER_PASSWORD
+#   if [ ! "$JUPYTER_PASSWORD" = "" ]; then
+#     sudo sh -c "echo '$JUPYTER_PASSWORD' | passwd --stdin $JUPYTER_HUB_DEFAULT_USER"
+#   fi
+  
+#   sudo ln -sf /usr/local/bin/jupyterhub /usr/bin/
+#   sudo ln -sf /usr/local/bin/jupyterhub-singleuser /usr/bin/
+#   mkdir -p /mnt/jupyterhub
+#   cd /mnt/jupyterhub
+#   echo "Starting Jupyterhub"
+#   #sudo jupyterhub $SSL_OPTS_JUPYTERHUB --port=$JUPYTER_HUB_PORT --ip=$JUPYTER_HUB_IP --log-file=/var/log/jupyter/jupyterhub.log --config ~/.jupyter/jupyter_notebook_config.py &
+# #   sudo puppet apply << PUPPET_SCRIPT
+# #   include 'upstart'
+# #   upstart::job { 'jupyterhub':
+# #       description    => 'JupyterHub',
+# #       respawn        => true,
+# #       respawn_limit  => '0 10',
+# #       start_on       => 'runlevel [2345]',
+# #       stop_on        => 'runlevel [016]',
+# #       console        => 'output',
+# #       chdir          => '/mnt/jupyterhub',
+# #       env            => { 'NOTEBOOK_DIR' => '$NOTEBOOK_DIR', 'NODE_PATH' => '$NODE_PATH' },
+# #       exec           => 'sudo /usr/bin/jupyterhub --pid-file=/var/run/jupyter.pid $SSL_OPTS_JUPYTERHUB --port=$JUPYTER_HUB_PORT --ip=$JUPYTER_HUB_IP --log-file=/var/log/jupyter/jupyterhub.log --config /home/hadoop/.jupyter/jupyter_notebook_config.py'
+# #   }
+# # PUPPET_SCRIPT
+
+# fi
+
+# # cat << 'EOF' > /tmp/jupyter_logpusher.config
+# # {
+# #   "/var/log/jupyter/" : {
+# #     "includes" : [ "(.*)" ],
+# #     "s3Path" : "node/$instance-id/applications/jupyter/$0",
+# #     "retentionPeriod" : "5d",
+# #     "logType" : [ "USER_LOG", "SYSTEM_LOG" ]
+# #   }
+# # }
+# # EOF
+# # cat /tmp/jupyter_logpusher.config | sudo tee -a /etc/logpusher/jupyter.config
+
+# fi
+# echo "Bootstrap action finished"

--- a/src/jupyter_notebook_config.py
+++ b/src/jupyter_notebook_config.py
@@ -1,6 +1,6 @@
-c.NotebookApp.open_browser = False
-c.NotebookApp.ip='0.0.0.0' #'*'
-c.NotebookApp.port = 8192
-c.NotebookApp.password = u'sha1:45f7d7ac038c:c36b98f22eac5921c435095af65a9a00b0e1eeb9'
-c.Authenticator.admin_users = {'jupyter'}
-c.LocalAuthenticator.create_system_users = True
+# c.NotebookApp.open_browser = False
+# c.NotebookApp.ip='0.0.0.0' #'*'
+# c.NotebookApp.port = 8192
+# c.NotebookApp.password = u'sha1:45f7d7ac038c:c36b98f22eac5921c435095af65a9a00b0e1eeb9'
+# c.Authenticator.admin_users = {'jupyter'}
+# c.LocalAuthenticator.create_system_users = True

--- a/src/jupyter_run.sh
+++ b/src/jupyter_run.sh
@@ -1,30 +1,30 @@
-#!/bin/bash
+# #!/bin/bash
 
-export SPARK_HOME=/usr/lib/spark
-export PYSPARK_PYTHON=python3
-export HAIL_HOME=/opt/hail-on-EMR
-export HOME=/home/hadoop
+# export SPARK_HOME=/usr/lib/spark
+# export PYSPARK_PYTHON=python3
+# export HAIL_HOME=/opt/hail-on-EMR
+# export HOME=/home/hadoop
 
-export PYTHONPATH="/home/hadoop/hail-python.zip:$SPARK_HOME/python:${SPARK_HOME}/python/lib/py4j-src.zip"
-echo "PYTHONPATH: ${PYTHONPATH}"
+# export PYTHONPATH="/home/hadoop/hail-python.zip:$SPARK_HOME/python:${SPARK_HOME}/python/lib/py4j-src.zip"
+# echo "PYTHONPATH: ${PYTHONPATH}"
 
-export PYSPARK_PYTHON=python3
-echo "PYSPARK_PYTHON: ${PYSPARK_PYTHON}"
+# export PYSPARK_PYTHON=python3
+# echo "PYSPARK_PYTHON: ${PYSPARK_PYTHON}"
 
 
-JAR_PATH="/home/hadoop/hail-all-spark.jar:/usr/share/aws/emr/emrfs/lib/emrfs-hadoop-assembly-2.*.0.jar"
-export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath='$JAR_PATH' --conf spark.executor.extraClassPath='$JAR_PATH' pyspark-shell"
-echo "PYSPARK_SUBMIT_ARGS: ${PYSPARK_SUBMIT_ARGS}"
+# JAR_PATH="/home/hadoop/hail-all-spark.jar:/usr/share/aws/emr/emrfs/lib/emrfs-hadoop-assembly-2.*.0.jar"
+# export PYSPARK_SUBMIT_ARGS="--conf spark.driver.extraClassPath='$JAR_PATH' --conf spark.executor.extraClassPath='$JAR_PATH' pyspark-shell"
+# echo "PYSPARK_SUBMIT_ARGS: ${PYSPARK_SUBMIT_ARGS}"
 
-sudo mkdir -p $HOME/.jupyter
-cp /opt/hail-on-EMR/src/jupyter_notebook_config.py $HOME/.jupyter/
+# sudo mkdir -p $HOME/.jupyter
+# cp /opt/hail-on-EMR/src/jupyter_notebook_config.py $HOME/.jupyter/
 
-sudo mkdir -p $HOME/notebook/
-sudo chmod -R 777 $HOME/notebook
-cd $HOME/notebook/
+# sudo mkdir -p $HOME/notebook/
+# sudo chmod -R 777 $HOME/notebook
+# cd $HOME/notebook/
 
-JUPYTERPID=`cat /tmp/jupyter_notebook.pid`
-kill $JUPYTERPID
-nohup jupyter notebook >/tmp/jupyter_notebook.log 2>&1 &
-echo $! > /tmp/jupyter_notebook.pid
-echo "Started JupyterNotebook in the background."
+# JUPYTERPID=`cat /tmp/jupyter_notebook.pid`
+# kill $JUPYTERPID
+# nohup jupyter notebook >/tmp/jupyter_notebook.log 2>&1 &
+# echo $! > /tmp/jupyter_notebook.pid
+# echo "Started JupyterNotebook in the background."

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,65 +1,65 @@
-#!/bin/bash -x -e
+# #!/bin/bash -x -e
 
-echo "Generating the EMR cluster. See log details at /tmp/cloudcreation_log.out"
+# echo "Generating the EMR cluster. See log details at /tmp/cloudcreation_log.out"
 
-# Install brew
-OS=$(uname)
-if [ "$OS" == "Darwin" ]; then
-	echo "Installing brew for Mac"
-	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-elif [ "$OS" == "Linux" ]; then
-	echo "Installing brew for Linux"
-	sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
-		if [ ! -f ~/.bashrc ]; then # Fedora, Red Hat, CentOS, etc.
-			sudo yum -y groupinstall 'Development Tools'
-		elif [ ! -f ~/.bashrc ]; then # Debian, Ubuntu, etc.
-			sudo apt-get -y install build-essential
-		fi
-	echo 'export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"' >> ~/.bashrc
-	source ~/.bashrc
-fi
+# # Install brew
+# OS=$(uname)
+# if [ "$OS" == "Darwin" ]; then
+# 	echo "Installing brew for Mac"
+# 	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+# elif [ "$OS" == "Linux" ]; then
+# 	echo "Installing brew for Linux"
+# 	sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+# 		if [ ! -f ~/.bashrc ]; then # Fedora, Red Hat, CentOS, etc.
+# 			sudo yum -y groupinstall 'Development Tools'
+# 		elif [ ! -f ~/.bashrc ]; then # Debian, Ubuntu, etc.
+# 			sudo apt-get -y install build-essential
+# 		fi
+# 	echo 'export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"' >> ~/.bashrc
+# 	source ~/.bashrc
+# fi
 
-# Check if python3 is installed 
-PYTH=$(which python3)
-if [ -z "$PYTH" ]; then
-	echo "\n\nInstalling Python3..."
-	sleep 1
-	brew install python3
-fi
+# # Check if python3 is installed 
+# PYTH=$(which python3)
+# if [ -z "$PYTH" ]; then
+# 	echo "\n\nInstalling Python3..."
+# 	sleep 1
+# 	brew install python3
+# fi
 
-pip install --upgrade pip
+# pip install --upgrade pip
 
-# Install the AWS command tool
-brew install awscli
+# # Install the AWS command tool
+# brew install awscli
 
 
-# Save the AWS Keys to the default folder 
-CREDENTIALS=$(ls  ~/.aws)
-if [ -z "$CREDENTIALS" ]; then
-	echo "Your AWS configuration file is required!"
-	echo "For help visit:"
-	echo "https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html"
-	echo "See your accessKeys.csv file to find the Access Keys"
-	echo "\n\n Your inputs should look like this:\n\n"
-	echo "AWS Access Key ID [None]: AKIAIEXAMPLEKEY"
-	echo "AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-	echo "Default region name [None]: us-east-1"
-	echo "Default output format [None]: json"
-	echo "\n\n"
-	aws configure
-else 
-	echo "Using existing AWS credentials..."
-	echo "To reconfigure run: aws configure"
-	echo "For help visit: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html"
-	echo "\n\n"
-	read -n 1 -s -r -p "Press any key to continue cloudformation"
-fi
+# # Save the AWS Keys to the default folder 
+# CREDENTIALS=$(ls  ~/.aws)
+# if [ -z "$CREDENTIALS" ]; then
+# 	echo "Your AWS configuration file is required!"
+# 	echo "For help visit:"
+# 	echo "https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html"
+# 	echo "See your accessKeys.csv file to find the Access Keys"
+# 	echo "\n\n Your inputs should look like this:\n\n"
+# 	echo "AWS Access Key ID [None]: AKIAIEXAMPLEKEY"
+# 	echo "AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+# 	echo "Default region name [None]: us-east-1"
+# 	echo "Default output format [None]: json"
+# 	echo "\n\n"
+# 	aws configure
+# else 
+# 	echo "Using existing AWS credentials..."
+# 	echo "To reconfigure run: aws configure"
+# 	echo "For help visit: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html"
+# 	echo "\n\n"
+# 	read -n 1 -s -r -p "Press any key to continue cloudformation"
+# fi
 
-echo "\n\nInstalling required packages"
-pip3 install boto3 pandas botocore paramiko pyyaml -q #parallel-ssh 
-# pip install -U pip -q 
-# pip uninstall -y greenlet -q
-# pip install -Iv greenlet==0.4.13 -q
+# echo "\n\nInstalling required packages"
+# pip3 install boto3 pandas botocore paramiko pyyaml -q #parallel-ssh 
+# # pip install -U pip -q 
+# # pip uninstall -y greenlet -q
+# # pip install -Iv greenlet==0.4.13 -q
 
-echo "Starting EMR cluster. This operation takes 5-7 minutes..."
-python3 install2.py
+# echo "Starting EMR cluster. This operation takes 5-7 minutes..."
+# python3 install2.py

--- a/src/setup.sh
+++ b/src/setup.sh
@@ -1,28 +1,28 @@
-#!/bin/sh -x
+# #!/bin/sh -x
 
-logger_debug() {
-	MSG=$1
-	echo "`date` DEBUG ${MSG}"
-}
+# logger_debug() {
+# 	MSG=$1
+# 	echo "`date` DEBUG ${MSG}"
+# }
 
-logger_error() {
-	MSG=$1
-	echo "`date` ERROR ${MSG}"
-}
+# logger_error() {
+# 	MSG=$1
+# 	echo "`date` ERROR ${MSG}"
+# }
 
-logger_debug "Clean up previous virtualenv"
-rm -fR bin include lib lib64 local pip-selfcheck.json
+# logger_debug "Clean up previous virtualenv"
+# rm -fR bin include lib lib64 local pip-selfcheck.json
 
-logger_debug "Creating local Python environment"
-python3 -m venv .
+# logger_debug "Creating local Python environment"
+# python3 -m venv .
 
-logger_debug "Activating local Python environment"
-source bin/activate
+# logger_debug "Activating local Python environment"
+# source bin/activate
 
-logger_debug "Installing required libraries"
-python3 -m pip install --upgrade pip
-python3 -m pip install -r requirements.txt
-logger_debug "Status and Context check of hail environment"
+# logger_debug "Installing required libraries"
+# python3 -m pip install --upgrade pip
+# python3 -m pip install -r requirements.txt
+# logger_debug "Status and Context check of hail environment"
 
-export HAIL_HOME=`pwd`
-./hail_submit.sh src/scripts/context.py
+# export HAIL_HOME=`pwd`
+# ./hail_submit.sh src/scripts/context.py


### PR DESCRIPTION
## Issues

I encounter issues of environment to run ```install2.py```: python modules absent or install in incompatible version. The upstream project use **Homebrew** as environment manager, that is in Ruby and require a bunch of additional installation...

## Env

I include in this PR a **Conda** environment recipe. **Conda** is based on python and fit well in our stack.

## README

I updated the ```README.md``` to incude some indication about the **Conda** environment and adjust the installation workflow to our recent modifications. I also commented out the section about Jupyternotebook as we do not install it. (Need to document JupyterHub usage)

## Config

* I noticed some changes in the config file ```hail02_EMR.yaml```. I updated the README accordingly.
* I also added a option ```REGION``` in the config and the AWS command

## Deprecated files

I commented out some files that we are not using anymore ( eventually we should delete the files)

* src/EMR_deploy_and_install.py
* src/hail_cloudformation_emr.sh
* src/jupyter_build.sh
* src/jupyter_extraRlibraries_install.sh
* src/jupyter_installer.sh
* src/jupyter_notebook_config.py
* src/jupyter_run.sh
* src/run.sh
* src/setup.sh
* src/VEP_run.sh

## Install
I made some modification to ```install2.py```

* In the function ```launch_emr```: Do not print the commands that display the full path of the ssh key.
* l.66: Do not copy jupyter_pw, as we do not use jupyter notebook that way
* l.89: Solve a warning about ```yaml.load``` that change signature for security reason.
* l.95: Break down the aws command in multi-lines, that will be easier to debug. Update ENV variable names and add ```REGION```
* l.100-l-120: Modify cluster_id parsing to match the boto3 version installed in conda environment.

## END
 
